### PR TITLE
Fix forum topic message routing: use group chat_id instead of user_id

### DIFF
--- a/src/ccbot/handlers/history.py
+++ b/src/ccbot/handlers/history.py
@@ -12,10 +12,10 @@ from typing import Any
 
 from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup
 
+from ..config import config
 from ..session import session_manager
 from ..telegram_sender import split_message
 from ..transcript_parser import TranscriptParser
-from ..config import config
 from .callback_data import CB_HISTORY_NEXT, CB_HISTORY_PREV
 from .message_sender import safe_edit, safe_reply, safe_send
 
@@ -124,7 +124,9 @@ async def send_history(
                 await safe_edit(target, text, reply_markup=keyboard)
             elif bot is not None and user_id is not None:
                 await safe_send(
-                    bot, user_id, text,
+                    bot,
+                    session_manager.resolve_chat_id(user_id, message_thread_id),
+                    text,
                     message_thread_id=message_thread_id,
                     reply_markup=keyboard,
                 )
@@ -198,7 +200,9 @@ async def send_history(
     elif bot is not None and user_id is not None:
         # Direct send mode (for unread catch-up after window switch)
         await safe_send(
-            bot, user_id, text,
+            bot,
+            session_manager.resolve_chat_id(user_id, message_thread_id),
+            text,
             message_thread_id=message_thread_id,
             reply_markup=keyboard,
         )

--- a/src/ccbot/handlers/message_sender.py
+++ b/src/ccbot/handlers/message_sender.py
@@ -77,17 +77,19 @@ async def _send_with_fallback(
 
 async def rate_limit_send_message(
     bot: Bot,
-    user_id: int,
+    chat_id: int,
     text: str,
     **kwargs: Any,
 ) -> Message | None:
     """Rate-limited send with MarkdownV2 fallback.
 
     Combines rate_limit_send() + _send_with_fallback() for convenience.
+    The chat_id should be the group chat ID for forum topics, or the user ID
+    for direct messages.  Use session_manager.resolve_chat_id() to obtain it.
     Returns the sent Message on success, None on failure.
     """
-    await rate_limit_send(user_id)
-    return await _send_with_fallback(bot, user_id, text, **kwargs)
+    await rate_limit_send(chat_id)
+    return await _send_with_fallback(bot, chat_id, text, **kwargs)
 
 
 async def safe_reply(message: Message, text: str, **kwargs: Any) -> Message:

--- a/src/ccbot/handlers/status_polling.py
+++ b/src/ccbot/handlers/status_polling.py
@@ -112,7 +112,7 @@ async def status_poll_loop(bot: Bot) -> None:
                 ):
                     try:
                         await bot.unpin_all_forum_topic_messages(
-                            chat_id=user_id,
+                            chat_id=session_manager.resolve_chat_id(user_id, thread_id),
                             message_thread_id=thread_id,
                         )
                     except BadRequest as e:


### PR DESCRIPTION
## Summary

When CCBot runs in a Telegram supergroup with forum/topics mode enabled, all Bot API calls (sending messages, editing messages, deleting messages, pinning, etc.) require the **group chat_id**, not the user's ID. The existing code passes `user_id` as `chat_id` everywhere, which causes all message operations to fail silently or error in forum topic mode.

This PR:

- Adds `resolve_chat_id(user_id, thread_id)` to `SessionManager` that returns the group chat ID when operating in a forum topic, falling back to `user_id` for direct messages
- Captures the group `chat_id` from incoming messages/callbacks and persists it in `state.json`
- Replaces all `user_id` → `chat_id` references in message sending, editing, deleting, and status polling across all handlers

## Changes

- **`session.py`**: New `group_chat_ids` dict on `SessionManager`, with `set_group_chat_id()` and `resolve_chat_id()` methods. State is persisted/loaded with `state.json`.
- **`bot.py`**: Captures group `chat_id` from incoming messages and callbacks. Uses `resolve_chat_id()` for topic rename and error messages after directory selection.
- **`handlers/message_queue.py`**: All `bot.edit_message_text()`, `bot.delete_message()`, `bot.send_chat_action()`, and `rate_limit_send_message()` calls now use resolved chat_id.
- **`handlers/message_sender.py`**: `rate_limit_send_message()` parameter renamed from `user_id` to `chat_id` to reflect actual usage.
- **`handlers/interactive_ui.py`**: Interactive UI message sending/editing/deleting uses resolved chat_id.
- **`handlers/history.py`**: History pagination messages use resolved chat_id.
- **`handlers/status_polling.py`**: `unpin_all_forum_topic_messages` uses resolved chat_id.

## Test plan

- [x] Create a Telegram supergroup with Topics/Forum mode enabled
- [x] Add bot as admin, send a message in a topic
- [x] Verify Claude responses appear in the correct topic
- [x] Verify interactive UI (permission prompts, plan approvals) render correctly
- [x] Verify `/history` pagination works
- [x] Verify status messages (typing indicator, status line) display and clear properly
- [x] Verify topic rename works after directory selection