### PR TITLE
fix: support multiple supergroups per user via composite group_chat_ids key

### DIFF
--- a/src/ccbot/session.py
+++ b/src/ccbot/session.py
@@ -103,7 +103,8 @@ class SessionManager:
     window_states: dict[str, WindowState] = field(default_factory=dict)
     user_window_offsets: dict[int, dict[str, int]] = field(default_factory=dict)
     thread_bindings: dict[int, dict[int, str]] = field(default_factory=dict)
-    group_chat_ids: dict[int, int] = field(default_factory=dict)
+    # group_chat_ids: "user_id:thread_id" -> chat_id (supports multiple groups per user)
+    group_chat_ids: dict[str, int] = field(default_factory=dict)
 
     # Reverse index: (user_id, window_name) -> thread_id for O(1) inbound lookups
     _window_to_thread: dict[tuple[int, str], int] = field(
@@ -134,10 +135,7 @@ class SessionManager:
                 str(uid): {str(tid): wname for tid, wname in bindings.items()}
                 for uid, bindings in self.thread_bindings.items()
             },
-            "group_chat_ids": {
-                str(uid): chat_id
-                for uid, chat_id in self.group_chat_ids.items()
-            },
+            "group_chat_ids": self.group_chat_ids,
         }
         atomic_write_json(config.state_file, state)
         logger.debug("State saved to %s", config.state_file)
@@ -159,10 +157,7 @@ class SessionManager:
                     int(uid): {int(tid): wname for tid, wname in bindings.items()}
                     for uid, bindings in state.get("thread_bindings", {}).items()
                 }
-                self.group_chat_ids = {
-                    int(uid): int(chat_id)
-                    for uid, chat_id in state.get("group_chat_ids", {}).items()
-                }
+                self.group_chat_ids = state.get("group_chat_ids", {})
             except (json.JSONDecodeError, ValueError) as e:
                 logger.warning(f"Failed to load state: {e}")
                 self.window_states = {}
@@ -497,23 +492,29 @@ class SessionManager:
 
     # --- Group chat ID management ---
 
-    def set_group_chat_id(self, user_id: int, chat_id: int) -> None:
-        """Store the group chat ID for a user (for forum topic message routing)."""
-        if self.group_chat_ids.get(user_id) != chat_id:
-            self.group_chat_ids[user_id] = chat_id
+    def set_group_chat_id(self, user_id: int, thread_id: int, chat_id: int) -> None:
+        """Store the group chat ID for a user's thread (for forum topic message routing).
+
+        Uses composite key "user_id:thread_id" to support multiple groups per user.
+        """
+        key = f"{user_id}:{thread_id}"
+        if self.group_chat_ids.get(key) != chat_id:
+            self.group_chat_ids[key] = chat_id
             self._save_state()
             logger.info(
-                f"Stored group chat_id {chat_id} for user {user_id}"
+                f"Stored group chat_id {chat_id} for user {user_id}, thread {thread_id}"
             )
 
     def resolve_chat_id(self, user_id: int, thread_id: int | None = None) -> int:
         """Resolve the chat_id for sending messages.
 
-        In forum topics (thread_id is set), returns the stored group chat_id.
+        In forum topics (thread_id is set), returns the stored group chat_id
+        for that specific thread (user_id:thread_id).
         Falls back to user_id for direct messages or if no group_id stored.
         """
         if thread_id is not None:
-            group_id = self.group_chat_ids.get(user_id)
+            key = f"{user_id}:{thread_id}"
+            group_id = self.group_chat_ids.get(key)
             if group_id is not None:
                 return group_id
         return user_id


### PR DESCRIPTION
## Problem
  `group_chat_ids` used `user_id` as key, so only one chat_id could be stored per user. When a user interacted with
  multiple supergrupos, the last one would overwrite the previous, breaking message routing.

  ## Solution
  Change `group_chat_ids` from `dict[int, int]` to `dict[str, int]` using composite key `"user_id:thread_id"` ->
  `chat_id`. This allows each (user, thread) pair to have its own group chat_id.

  ## Changes
  - `session.py`: Updated `group_chat_ids` type, `set_group_chat_id()`, `resolve_chat_id()`
  - `bot.py`: Pass `thread_id` to `set_group_chat_id()` in all handlers

  ## State Format
  `group_chat_ids` now uses `"user_id:thread_id"` string keys instead of integer user_id keys.

  ## Testing
  Tested with multiple supergrupos - each now correctly routes messages to its respective chat_id.

  Fixes issue where users could only use one supergrupo at a time.