### PR TITLE
feat: configurable config directory via CCBOT_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Control Claude Code sessions remotely via Telegram — monitor, interact, and ma
 
 https://github.com/user-attachments/assets/15ffb38e-5eb9-4720-93b9-412e4961dc93
 
-
 ## Why CCBot?
 
 Claude Code runs in your terminal. When you step away from your computer — commuting, on the couch, or just away from your desk — the session keeps working, but you lose visibility and control.
@@ -58,20 +57,22 @@ cp .env.example .env
 
 **Required:**
 
-| Variable | Description |
-|---|---|
-| `TELEGRAM_BOT_TOKEN` | Bot token from @BotFather |
-| `ALLOWED_USERS` | Comma-separated Telegram user IDs |
+| Variable             | Description                       |
+| -------------------- | --------------------------------- |
+| `TELEGRAM_BOT_TOKEN` | Bot token from @BotFather         |
+| `ALLOWED_USERS`      | Comma-separated Telegram user IDs |
 
 **Optional:**
 
-| Variable | Default | Description |
-|---|---|---|
-| `TMUX_SESSION_NAME` | `ccbot` | Tmux session name |
-| `CLAUDE_COMMAND` | `claude` | Command to run in new windows |
-| `MONITOR_POLL_INTERVAL` | `2.0` | Polling interval in seconds |
+| Variable                | Default    | Description                                      |
+| ----------------------- | ---------- | ------------------------------------------------ |
+| `CCBOT_DIR`             | `~/.ccbot` | Config/state directory (`.env` loaded from here) |
+| `TMUX_SESSION_NAME`     | `ccbot`    | Tmux session name                                |
+| `CLAUDE_COMMAND`        | `claude`   | Command to run in new windows                    |
+| `MONITOR_POLL_INTERVAL` | `2.0`      | Polling interval in seconds                      |
 
 > If running on a VPS where there's no interactive terminal to approve permissions, consider:
+>
 > ```
 > CLAUDE_COMMAND=IS_SANDBOX=1 claude --dangerously-skip-permissions
 > ```
@@ -98,7 +99,7 @@ Or manually add to `~/.claude/settings.json`:
 }
 ```
 
-This writes window-session mappings to `~/.ccbot/session_map.json`, so the bot automatically tracks which Claude session is running in each tmux window — even after `/clear` or session restarts.
+This writes window-session mappings to `$CCBOT_DIR/session_map.json` (`~/.ccbot/` by default), so the bot automatically tracks which Claude session is running in each tmux window — even after `/clear` or session restarts.
 
 ## Usage
 
@@ -110,22 +111,22 @@ uv run ccbot
 
 **Bot commands:**
 
-| Command | Description |
-|---|---|
-| `/start` | Show welcome message |
-| `/history` | Message history for this topic |
-| `/screenshot` | Capture terminal screenshot |
-| `/esc` | Send Escape to interrupt Claude |
+| Command       | Description                     |
+| ------------- | ------------------------------- |
+| `/start`      | Show welcome message            |
+| `/history`    | Message history for this topic  |
+| `/screenshot` | Capture terminal screenshot     |
+| `/esc`        | Send Escape to interrupt Claude |
 
 **Claude Code commands (forwarded via tmux):**
 
-| Command | Description |
-|---|---|
-| `/clear` | Clear conversation history |
+| Command    | Description                  |
+| ---------- | ---------------------------- |
+| `/clear`   | Clear conversation history   |
 | `/compact` | Compact conversation context |
-| `/cost` | Show token/cost usage |
-| `/help` | Show Claude Code help |
-| `/memory` | Edit CLAUDE.md |
+| `/cost`    | Show token/cost usage        |
+| `/help`    | Show Claude Code help        |
+| `/memory`  | Edit CLAUDE.md               |
 
 Any unrecognized `/command` is also forwarded to Claude Code as-is (e.g. `/review`, `/doctor`, `/init`).
 
@@ -169,6 +170,7 @@ I'll look into the login bug...
 ### Notifications
 
 The monitor polls session JSONL files every 2 seconds and sends notifications for:
+
 - **Assistant responses** — Claude's text replies
 - **Thinking content** — Shown as expandable blockquotes
 - **Tool use/result** — Summarized with stats (e.g. "Read 42 lines", "Found 5 matches")
@@ -197,12 +199,12 @@ The window must be in the `ccbot` tmux session (configurable via `TMUX_SESSION_N
 
 ## Data Storage
 
-| Path | Description |
-|---|---|
-| `~/.ccbot/state.json` | Thread bindings, window states, and per-user read offsets |
-| `~/.ccbot/session_map.json` | Hook-generated `{tmux_session:window_name: {session_id, cwd}}` mappings |
-| `~/.ccbot/monitor_state.json` | Monitor byte offsets per session (prevents duplicate notifications) |
-| `~/.claude/projects/` | Claude Code session data (read-only) |
+| Path                            | Description                                                             |
+| ------------------------------- | ----------------------------------------------------------------------- |
+| `$CCBOT_DIR/state.json`         | Thread bindings, window states, and per-user read offsets               |
+| `$CCBOT_DIR/session_map.json`   | Hook-generated `{tmux_session:window_name: {session_id, cwd}}` mappings |
+| `$CCBOT_DIR/monitor_state.json` | Monitor byte offsets per session (prevents duplicate notifications)     |
+| `~/.claude/projects/`           | Claude Code session data (read-only)                                    |
 
 ## File Structure
 

--- a/src/ccbot/utils.py
+++ b/src/ccbot/utils.py
@@ -1,6 +1,7 @@
 """Shared utility functions used across multiple CCBot modules.
 
 Provides:
+  - ccbot_dir(): resolve config directory from CCBOT_DIR env var.
   - atomic_write_json(): crash-safe JSON file writes via temp+rename.
   - read_cwd_from_jsonl(): extract the cwd field from the first JSONL entry.
 """
@@ -12,6 +13,14 @@ import os
 import tempfile
 from pathlib import Path
 from typing import Any
+
+CCBOT_DIR_ENV = "CCBOT_DIR"
+
+
+def ccbot_dir() -> Path:
+    """Resolve config directory from CCBOT_DIR env var or default ~/.ccbot."""
+    raw = os.environ.get(CCBOT_DIR_ENV, "")
+    return Path(raw) if raw else Path.home() / ".ccbot"
 
 
 def atomic_write_json(path: Path, data: Any, indent: int = 2) -> None:


### PR DESCRIPTION
## Summary

- Add `CCBOT_DIR` environment variable to configure the config directory (default: `~/.ccbot`)
- Extract shared `ccbot_dir()` utility function used by both `config.py` and `hook.py`
- Load `.env` from the config directory instead of CWD, so `uv run ccbot` works from any directory
- All state files (`state.json`, `session_map.json`, `monitor_state.json`) are resolved relative to `CCBOT_DIR`

## Motivation

Running `uv run ccbot` from a directory other than the project root fails because `load_dotenv()` looks for `.env` in CWD. This change makes the bot directory-independent by centralizing all config/state file resolution through `CCBOT_DIR`.

## Changes

| File | Change |
|------|--------|
| `src/ccbot/utils.py` | Add `ccbot_dir()` function with empty-string guard |
| `src/ccbot/config.py` | Use `ccbot_dir()` for all state file paths, load `.env` from config dir |
| `src/ccbot/hook.py` | Use lazy import of `ccbot_dir()` instead of hardcoded `~/.ccbot` path |
| `README.md` | Document `CCBOT_DIR` env var and updated data storage paths |

## Test plan

- [ ] Run `CCBOT_DIR=/tmp/test-ccbot uv run ccbot` — verify state files created in `/tmp/test-ccbot/`
- [ ] Run `uv run ccbot` without `CCBOT_DIR` — verify default `~/.ccbot` behavior unchanged
- [ ] Run `uv run ccbot hook` — verify `session_map.json` written to correct directory
- [ ] Set `CCBOT_DIR=""` — verify fallback to `~/.ccbot` (not CWD)