### PR TITLE
chore: modernize for Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ccbot"
 version = "0.1.0"
 description = "Telegram Bot for monitoring Claude Code sessions"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.14"
 dependencies = [
     "python-telegram-bot>=21.0",
     "python-dotenv>=1.0.0",
@@ -28,3 +28,11 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/ccbot"]
+
+# Pin formatter target to py313 — black and ruff format have a bug with py314
+# that strips parentheses from `except (ExcA, ExcB):` (misapplying PEP 758).
+[tool.black]
+target-version = ["py313"]
+
+[tool.ruff]
+target-version = "py313"

--- a/src/ccbot/monitor_state.py
+++ b/src/ccbot/monitor_state.py
@@ -7,8 +7,6 @@ incremental reading after restarts without re-sending old messages.
 Key classes: MonitorState, TrackedSession.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 from dataclasses import asdict, dataclass, field
@@ -31,7 +29,7 @@ class TrackedSession:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> TrackedSession:
+    def from_dict(cls, data: dict[str, Any]) -> "TrackedSession":
         """Create from dict."""
         return cls(
             session_id=data.get("session_id", ""),
@@ -64,7 +62,9 @@ class MonitorState:
             self.tracked_sessions = {
                 k: TrackedSession.from_dict(v) for k, v in sessions.items()
             }
-            logger.info(f"Loaded {len(self.tracked_sessions)} tracked sessions from state")
+            logger.info(
+                f"Loaded {len(self.tracked_sessions)} tracked sessions from state"
+            )
         except (json.JSONDecodeError, KeyError, TypeError) as e:
             logger.warning(f"Failed to load state file: {e}")
             self.tracked_sessions = {}
@@ -82,7 +82,9 @@ class MonitorState:
         try:
             atomic_write_json(self.state_file, data)
             self._dirty = False
-            logger.debug("Saved %d tracked sessions to state", len(self.tracked_sessions))
+            logger.debug(
+                "Saved %d tracked sessions to state", len(self.tracked_sessions)
+            )
         except OSError as e:
             logger.error("Failed to save state file: %s", e)
 
@@ -105,4 +107,3 @@ class MonitorState:
         """Save state only if it has been modified."""
         if self._dirty:
             self.save()
-

--- a/src/ccbot/session.py
+++ b/src/ccbot/session.py
@@ -19,8 +19,6 @@ Key methods for thread binding access:
   - find_users_for_session: Find all users bound to a session_id
 """
 
-from __future__ import annotations
-
 import asyncio
 import json
 import logging
@@ -81,7 +79,6 @@ class ClaudeSession:
         return self.summary
 
 
-
 @dataclass
 class UnreadInfo:
     """Information about unread messages for a user's window."""
@@ -124,12 +121,9 @@ class SessionManager:
 
     def _save_state(self) -> None:
         state = {
-            "window_states": {
-                k: v.to_dict() for k, v in self.window_states.items()
-            },
+            "window_states": {k: v.to_dict() for k, v in self.window_states.items()},
             "user_window_offsets": {
-                str(uid): offsets
-                for uid, offsets in self.user_window_offsets.items()
+                str(uid): offsets for uid, offsets in self.user_window_offsets.items()
             },
             "thread_bindings": {
                 str(uid): {str(tid): wname for tid, wname in bindings.items()}
@@ -172,7 +166,11 @@ class SessionManager:
 
         Returns True if the entry was found within timeout, False otherwise.
         """
-        logger.debug("Waiting for session_map entry: window=%s, timeout=%.1f", window_name, timeout)
+        logger.debug(
+            "Waiting for session_map entry: window=%s, timeout=%.1f",
+            window_name,
+            timeout,
+        )
         key = f"{config.tmux_session_name}:{window_name}"
         deadline = asyncio.get_event_loop().time() + timeout
         while asyncio.get_event_loop().time() < deadline:
@@ -184,13 +182,17 @@ class SessionManager:
                     info = session_map.get(key, {})
                     if info.get("session_id"):
                         # Found — load into window_states immediately
-                        logger.debug("session_map entry found for window %s", window_name)
+                        logger.debug(
+                            "session_map entry found for window %s", window_name
+                        )
                         await self.load_session_map()
                         return True
             except (json.JSONDecodeError, OSError):
                 pass
             await asyncio.sleep(interval)
-        logger.warning("Timed out waiting for session_map entry: window=%s", window_name)
+        logger.warning(
+            "Timed out waiting for session_map entry: window=%s", window_name
+        )
         return False
 
     async def load_session_map(self) -> None:
@@ -217,7 +219,7 @@ class SessionManager:
             # Only process entries for our tmux session
             if not key.startswith(prefix):
                 continue
-            window_name = key[len(prefix):]
+            window_name = key[len(prefix) :]
             valid_windows.add(window_name)
             new_sid = info.get("session_id", "")
             new_cwd = info.get("cwd", "")
@@ -322,7 +324,9 @@ class SessionManager:
 
     # --- Window → Session resolution ---
 
-    async def resolve_session_for_window(self, window_name: str) -> ClaudeSession | None:
+    async def resolve_session_for_window(
+        self, window_name: str
+    ) -> ClaudeSession | None:
         """Resolve a tmux window to the best matching Claude session.
 
         Uses persisted session_id + cwd to construct file path directly.
@@ -456,7 +460,9 @@ class SessionManager:
         return dict(self.thread_bindings.get(user_id, {}))
 
     def resolve_window_for_thread(
-        self, user_id: int, thread_id: int | None,
+        self,
+        user_id: int,
+        thread_id: int | None,
     ) -> str | None:
         """Resolve the tmux window for a user's thread.
 
@@ -477,7 +483,8 @@ class SessionManager:
                 yield user_id, thread_id, window_name
 
     async def find_users_for_session(
-        self, session_id: str,
+        self,
+        session_id: str,
     ) -> list[tuple[int, str, int]]:
         """Find all users whose thread-bound window maps to the given session_id.
 

--- a/src/ccbot/session_monitor.py
+++ b/src/ccbot/session_monitor.py
@@ -11,8 +11,6 @@ Optimizations: mtime cache skips unchanged files; byte offset avoids re-reading.
 Key classes: SessionMonitor, NewMessage, SessionInfo.
 """
 
-from __future__ import annotations
-
 import asyncio
 import json
 import logging
@@ -65,12 +63,14 @@ class SessionMonitor:
         poll_interval: float | None = None,
         state_file: Path | None = None,
     ):
-        self.projects_path = projects_path if projects_path is not None else config.claude_projects_path
-        self.poll_interval = poll_interval if poll_interval is not None else config.monitor_poll_interval
-
-        self.state = MonitorState(
-            state_file=state_file or config.monitor_state_file
+        self.projects_path = (
+            projects_path if projects_path is not None else config.claude_projects_path
         )
+        self.poll_interval = (
+            poll_interval if poll_interval is not None else config.monitor_poll_interval
+        )
+
+        self.state = MonitorState(state_file=state_file or config.monitor_state_file)
         self.state.load()
 
         self._running = False
@@ -144,10 +144,12 @@ class SessionMonitor:
                         indexed_ids.add(session_id)
                         file_path = Path(full_path)
                         if file_path.exists():
-                            sessions.append(SessionInfo(
-                                session_id=session_id,
-                                file_path=file_path,
-                            ))
+                            sessions.append(
+                                SessionInfo(
+                                    session_id=session_id,
+                                    file_path=file_path,
+                                )
+                            )
 
                 except (json.JSONDecodeError, OSError) as e:
                     logger.debug(f"Error reading index {index_file}: {e}")
@@ -162,7 +164,9 @@ class SessionMonitor:
                     # Determine project_path for this file
                     file_project_path = original_path
                     if not file_project_path:
-                        file_project_path = await asyncio.to_thread(read_cwd_from_jsonl, jsonl_file)
+                        file_project_path = await asyncio.to_thread(
+                            read_cwd_from_jsonl, jsonl_file
+                        )
                     if not file_project_path:
                         dir_name = project_dir.name
                         if dir_name.startswith("-"):
@@ -176,16 +180,20 @@ class SessionMonitor:
                     if norm_fp not in active_cwds:
                         continue
 
-                    sessions.append(SessionInfo(
-                        session_id=session_id,
-                        file_path=jsonl_file,
-                    ))
+                    sessions.append(
+                        SessionInfo(
+                            session_id=session_id,
+                            file_path=jsonl_file,
+                        )
+                    )
             except OSError as e:
                 logger.debug(f"Error scanning jsonl files in {project_dir}: {e}")
 
         return sessions
 
-    async def _read_new_lines(self, session: TrackedSession, file_path: Path) -> list[dict]:
+    async def _read_new_lines(
+        self, session: TrackedSession, file_path: Path
+    ) -> list[dict]:
         """Read new lines from a session file using byte offset for efficiency.
 
         Detects file truncation (e.g. after /clear) and resets offset.
@@ -291,7 +299,9 @@ class SessionMonitor:
                     continue
 
                 # File changed, read new content from last offset
-                new_entries = await self._read_new_lines(tracked, session_info.file_path)
+                new_entries = await self._read_new_lines(
+                    tracked, session_info.file_path
+                )
                 self._file_mtimes[session_info.session_id] = current_mtime
 
                 if new_entries:
@@ -303,7 +313,8 @@ class SessionMonitor:
                 # Parse new entries using the shared logic, carrying over pending tools
                 carry = self._pending_tools.get(session_info.session_id, {})
                 parsed_entries, remaining = TranscriptParser.parse_entries(
-                    new_entries, pending_tools=carry,
+                    new_entries,
+                    pending_tools=carry,
                 )
                 if remaining:
                     self._pending_tools[session_info.session_id] = remaining
@@ -316,15 +327,17 @@ class SessionMonitor:
                     # Skip user messages unless show_user_messages is enabled
                     if entry.role == "user" and not config.show_user_messages:
                         continue
-                    new_messages.append(NewMessage(
-                        session_id=session_info.session_id,
-                        text=entry.text,
-                        is_complete=True,
-                        content_type=entry.content_type,
-                        tool_use_id=entry.tool_use_id,
-                        role=entry.role,
-                        tool_name=entry.tool_name,
-                    ))
+                    new_messages.append(
+                        NewMessage(
+                            session_id=session_info.session_id,
+                            text=entry.text,
+                            is_complete=True,
+                            content_type=entry.content_type,
+                            tool_use_id=entry.tool_use_id,
+                            role=entry.role,
+                            tool_name=entry.tool_name,
+                        )
+                    )
 
                 self.state.update_session(tracked)
 
@@ -351,7 +364,7 @@ class SessionMonitor:
                     # Only process entries for our tmux session
                     if not key.startswith(prefix):
                         continue
-                    window_name = key[len(prefix):]
+                    window_name = key[len(prefix) :]
                     session_id = info.get("session_id", "")
                     if session_id:
                         window_to_session[window_name] = session_id
@@ -370,7 +383,9 @@ class SessionMonitor:
                 stale_sessions.append(session_id)
 
         if stale_sessions:
-            logger.info(f"[Startup cleanup] Removing {len(stale_sessions)} stale sessions")
+            logger.info(
+                f"[Startup cleanup] Removing {len(stale_sessions)} stale sessions"
+            )
             for session_id in stale_sessions:
                 self.state.remove_session(session_id)
                 self._file_mtimes.pop(session_id, None)
@@ -389,7 +404,9 @@ class SessionMonitor:
         for window_name, old_session_id in self._last_session_map.items():
             new_session_id = current_map.get(window_name)
             if new_session_id and new_session_id != old_session_id:
-                logger.info(f"Window '{window_name}' session changed: {old_session_id} -> {new_session_id}")
+                logger.info(
+                    f"Window '{window_name}' session changed: {old_session_id} -> {new_session_id}"
+                )
                 sessions_to_remove.add(old_session_id)
 
         # Check for deleted windows (window in old map but not in current)
@@ -399,7 +416,9 @@ class SessionMonitor:
 
         for window_name in deleted_windows:
             old_session_id = self._last_session_map[window_name]
-            logger.info(f"Window '{window_name}' deleted, removing session {old_session_id}")
+            logger.info(
+                f"Window '{window_name}' deleted, removing session {old_session_id}"
+            )
             sessions_to_remove.add(old_session_id)
 
         # Perform cleanup
@@ -444,9 +463,7 @@ class SessionMonitor:
                 for msg in new_messages:
                     status = "complete" if msg.is_complete else "streaming"
                     preview = msg.text[:80] + ("..." if len(msg.text) > 80 else "")
-                    logger.info(
-                        "[%s] session=%s: %s", status, msg.session_id, preview
-                    )
+                    logger.info("[%s] session=%s: %s", status, msg.session_id, preview)
                     if self._message_callback:
                         try:
                             await self._message_callback(msg)

--- a/src/ccbot/terminal_parser.py
+++ b/src/ccbot/terminal_parser.py
@@ -12,8 +12,6 @@ a changed Claude Code version, edit UI_PATTERNS / STATUS_SPINNERS.
 Key functions: is_interactive_ui(), extract_interactive_content(), parse_status_line().
 """
 
-from __future__ import annotations
-
 import re
 from dataclasses import dataclass
 
@@ -62,13 +60,13 @@ UI_PATTERNS: list[UIPattern] = [
     ),
     UIPattern(
         name="AskUserQuestion",
-        top=(re.compile(r"^\s*←\s+[☐✔☒]"),),   # Multi-tab: no bottom needed
+        top=(re.compile(r"^\s*←\s+[☐✔☒]"),),  # Multi-tab: no bottom needed
         bottom=(),
         min_gap=1,
     ),
     UIPattern(
         name="AskUserQuestion",
-        top=(re.compile(r"^\s*[☐✔☒]"),),        # Single-tab: bottom required
+        top=(re.compile(r"^\s*[☐✔☒]"),),  # Single-tab: bottom required
         bottom=(re.compile(r"^\s*Enter to select"),),
         min_gap=1,
     ),
@@ -101,8 +99,7 @@ _RE_LONG_DASH = re.compile(r"^─{5,}$")
 def _shorten_separators(text: str) -> str:
     """Replace lines of 5+ ─ characters with exactly ─────."""
     return "\n".join(
-        "─────" if _RE_LONG_DASH.match(line) else line
-        for line in text.split("\n")
+        "─────" if _RE_LONG_DASH.match(line) else line for line in text.split("\n")
     )
 
 

--- a/src/ccbot/tmux_manager.py
+++ b/src/ccbot/tmux_manager.py
@@ -11,8 +11,6 @@ All blocking libtmux calls are wrapped in asyncio.to_thread().
 Key class: TmuxManager (singleton instantiated as `tmux_manager`).
 """
 
-from __future__ import annotations
-
 import asyncio
 import logging
 from dataclasses import dataclass
@@ -83,6 +81,7 @@ class TmuxManager:
         Returns:
             List of TmuxWindow with window info and cwd
         """
+
         def _sync_list_windows() -> list[TmuxWindow]:
             windows = []
             session = self.get_session()
@@ -136,7 +135,6 @@ class TmuxManager:
         logger.debug("Window not found: %s", window_name)
         return None
 
-
     async def capture_pane(self, window_id: str, with_ansi: bool = False) -> str | None:
         """Capture the visible text content of a window's active pane.
 
@@ -151,14 +149,21 @@ class TmuxManager:
             # Use async subprocess to call tmux capture-pane -e for ANSI colors
             try:
                 proc = await asyncio.create_subprocess_exec(
-                    "tmux", "capture-pane", "-e", "-p", "-t", window_id,
+                    "tmux",
+                    "capture-pane",
+                    "-e",
+                    "-p",
+                    "-t",
+                    window_id,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
                 stdout, stderr = await proc.communicate()
                 if proc.returncode == 0:
                     return stdout.decode("utf-8")
-                logger.error(f"Failed to capture pane {window_id}: {stderr.decode('utf-8')}")
+                logger.error(
+                    f"Failed to capture pane {window_id}: {stderr.decode('utf-8')}"
+                )
                 return None
             except Exception as e:
                 logger.error(f"Unexpected error capturing pane {window_id}: {e}")
@@ -276,6 +281,7 @@ class TmuxManager:
 
     async def kill_window(self, window_id: str) -> bool:
         """Kill a tmux window by its ID."""
+
         def _sync_kill() -> bool:
             session = self.get_session()
             if not session:
@@ -294,7 +300,9 @@ class TmuxManager:
         return await asyncio.to_thread(_sync_kill)
 
     async def restart_claude_in_window(
-        self, window_name: str, command: str | None = None,
+        self,
+        window_name: str,
+        command: str | None = None,
     ) -> bool:
         """Restart Claude Code in an existing window.
 
@@ -316,10 +324,14 @@ class TmuxManager:
                 if not pane:
                     return False
                 pane.send_keys(cmd, enter=True)
-                logger.info("Restarted Claude Code in window '%s' (cmd=%s)", window_name, cmd)
+                logger.info(
+                    "Restarted Claude Code in window '%s' (cmd=%s)", window_name, cmd
+                )
                 return True
             except Exception as e:
-                logger.error("Failed to restart Claude in window '%s': %s", window_name, e)
+                logger.error(
+                    "Failed to restart Claude in window '%s': %s", window_name, e
+                )
                 return False
 
         return await asyncio.to_thread(_sync_restart)
@@ -374,7 +386,11 @@ class TmuxManager:
                         pane.send_keys(config.claude_command, enter=True)
 
                 logger.info("Created window '%s' at %s", final_window_name, path)
-                return True, f"Created window '{final_window_name}' at {path}", final_window_name
+                return (
+                    True,
+                    f"Created window '{final_window_name}' at {path}",
+                    final_window_name,
+                )
 
             except Exception as e:
                 logger.error(f"Failed to create window: {e}")

--- a/src/ccbot/utils.py
+++ b/src/ccbot/utils.py
@@ -5,8 +5,6 @@ Provides:
   - read_cwd_from_jsonl(): extract the cwd field from the first JSONL entry.
 """
 
-from __future__ import annotations
-
 import json
 import os
 import tempfile


### PR DESCRIPTION
## Summary

- Bump `requires-python` to `>=3.14`
- Remove `from __future__ import annotations` from 8 files (native in Python 3.14+)
- Use string annotation for `TrackedSession.from_dict()` forward reference
- Pin `black`/`ruff` target-version to `py313` to work around PEP 758 formatter bug

## Formatter bug workaround

Both `black 26.1.0` and `ruff format` with `--target-version py314` incorrectly strip parentheses from `except (ExcA, ExcB):` clauses, misapplying [PEP 758](https://peps.python.org/pep-0758/) (which only allows bare names without parens, not tuples). Pinning target to `py313` avoids the bug while still formatting all other Python 3.14 syntax correctly.

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | Bump `requires-python`, add `[tool.black]`/`[tool.ruff]` target-version |
| 8 source files | Remove `from __future__ import annotations` |
| `monitor_state.py` | String annotation `-> "TrackedSession"` for forward reference |

## Test plan

- [ ] `uv run pyright src/ccbot/` — 0 errors
- [ ] `uv run ruff check src/ccbot/` — no new errors (pre-existing F401 in markdown_v2.py unrelated)
- [ ] `uv run black --check src/ccbot/` — all files formatted correctly
- [ ] Verify `except (json.JSONDecodeError, OSError):` parentheses preserved after formatting