### PR TITLE
Add Edit tool permission prompt pattern to interactive UI detection

### DIFF
--- a/src/ccbot/terminal_parser.py
+++ b/src/ccbot/terminal_parser.py
@@ -73,7 +73,10 @@ UI_PATTERNS: list[UIPattern] = [
     ),
     UIPattern(
         name="PermissionPrompt",
-        top=(re.compile(r"^\s*Do you want to proceed\?"),),
+        top=(
+            re.compile(r"^\s*Do you want to proceed\?"),
+            re.compile(r"^\s*Do you want to make this edit"),
+        ),
         bottom=(re.compile(r"^\s*Esc to cancel"),),
     ),
     UIPattern(


### PR DESCRIPTION
## Summary

- Claude Code uses `"Do you want to make this edit to <file>?"` for Edit tool permission prompts, which differs from the existing `"Do you want to proceed?"` pattern used by Bash and other tools
- This caused Edit permission prompts to go undetected by `is_interactive_ui()`, so they were never forwarded to Telegram
- Added the Edit-specific prompt pattern to the `PermissionPrompt` UIPattern top markers

## Test plan

- [x] Verified Edit permission prompts now appear in Telegram with inline keyboard
- [x] Verified Bash permission prompts still work as before
- [x] `ruff check`, `ruff format --check`, `pyright` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)