### PR TITLE
fix: use group chat_id instead of user_id for outbound messages

### DIFF
--- a/src/ccbot/handlers/interactive_ui.py
+++ b/src/ccbot/handlers/interactive_ui.py
@@ -144,6 +144,7 @@ async def handle_interactive_ui(
     user_id: int,
     window_id: str,
     thread_id: int | None = None,
+    chat_id: int | None = None,
 ) -> bool:
     """Capture terminal and send interactive UI content to user.
 
@@ -152,7 +153,7 @@ async def handle_interactive_ui(
     False otherwise.
     """
     ikey = (user_id, thread_id or 0)
-    chat_id = user_id
+    chat_id = chat_id or user_id
     w = await tmux_manager.find_window_by_id(window_id)
     if not w:
         return False
@@ -231,6 +232,7 @@ async def clear_interactive_msg(
     user_id: int,
     bot: Bot | None = None,
     thread_id: int | None = None,
+    chat_id: int | None = None,
 ) -> None:
     """Clear tracked interactive message, delete from chat, and exit interactive mode."""
     ikey = (user_id, thread_id or 0)
@@ -243,8 +245,8 @@ async def clear_interactive_msg(
         msg_id,
     )
     if bot and msg_id:
-        chat_id = user_id
+        effective_chat_id = chat_id or user_id
         try:
-            await bot.delete_message(chat_id=chat_id, message_id=msg_id)
+            await bot.delete_message(chat_id=effective_chat_id, message_id=msg_id)
         except Exception:
             pass  # Message may already be deleted or too old


### PR DESCRIPTION
## Summary

- Store group `chat_id` in thread bindings so outbound messages (Claude responses, status updates, interactive UIs) target the group chat instead of the user's private DM
- Thread `chat_id` through the entire async outbound path: `session_manager` → `message_queue` → `interactive_ui` → `status_polling`
- Backward-compatible: old `state.json` with bare window_id strings are auto-migrated (fallback `chat_id = user_id`)

## Problem

All outbound messages were sent to `user_id` as `chat_id`. When a `message_thread_id` (forum topic) is included, Telegram rejects with "Message thread not found" because private chats don't have topics. This broke the core feature — forum-based multi-session Claude Code control.

The incoming reply path (`safe_reply`) worked fine because it replies to the original message context. The bug was only in the async outbound path: `session_monitor → handle_new_message → enqueue_content_message → send_with_fallback`.

## Changes

| File | What changed |
|---|---|
| `session.py` | `thread_bindings` values: `str` → `{"window_id": str, "chat_id": int}`. Added `get_chat_id_for_thread()`. `iter_thread_bindings` / `find_users_for_session` now yield/return 4-tuples. |
| `message_queue.py` | Added `chat_id` field to `MessageTask`. All worker functions compute `effective_chat_id = task.chat_id or user_id` for Telegram API calls. |
| `bot.py` | `bind_thread` calls pass `chat_id=update.effective_chat.id`. `handle_new_message` unpacks 4-tuple. `edit_forum_topic` / `safe_send` use group chat_id. |
| `interactive_ui.py` | `handle_interactive_ui` / `clear_interactive_msg` accept and use `chat_id`. |
| `status_polling.py` | `status_poll_loop` unpacks 4-tuple. `update_status_message` forwards `chat_id`. |
| `tests/test_session.py` | Updated existing test, added 4 new tests for chat_id functionality. |

## Test plan

- [x] All 196 existing + new tests pass
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `pyright` — 0 new errors (3 pre-existing)
- [x] Cleared state, restarted service, verified responses arrive in Telegram group topics

🤖 Generated with [Claude Code](https://claude.com/claude-code)