### PR TITLE
fix: use group chat_id instead of user_id for supergroup forum topic routing

### DIFF
--- a/src/ccbot/handlers/history.py
+++ b/src/ccbot/handlers/history.py
@@ -141,7 +141,7 @@ async def send_history(
             elif bot is not None and user_id is not None:
                 await safe_send(
                     bot,
-                    user_id,
+                    session_manager.resolve_chat_id(user_id, message_thread_id),
                     text,
                     message_thread_id=message_thread_id,
                     reply_markup=keyboard,
@@ -219,7 +219,7 @@ async def send_history(
         # Direct send mode (for unread catch-up after window switch)
         await safe_send(
             bot,
-            user_id,
+            session_manager.resolve_chat_id(user_id, message_thread_id),
             text,
             message_thread_id=message_thread_id,
             reply_markup=keyboard,

--- a/src/ccbot/handlers/interactive_ui.py
+++ b/src/ccbot/handlers/interactive_ui.py
@@ -18,6 +18,7 @@ import logging
 
 from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup
 
+from ..session import session_manager
 from ..terminal_parser import extract_interactive_content, is_interactive_ui
 from ..tmux_manager import tmux_manager
 from .callback_data import (
@@ -152,7 +153,7 @@ async def handle_interactive_ui(
     False otherwise.
     """
     ikey = (user_id, thread_id or 0)
-    chat_id = user_id
+    chat_id = session_manager.resolve_chat_id(user_id, thread_id)
     w = await tmux_manager.find_window_by_id(window_id)
     if not w:
         return False
@@ -243,7 +244,7 @@ async def clear_interactive_msg(
         msg_id,
     )
     if bot and msg_id:
-        chat_id = user_id
+        chat_id = session_manager.resolve_chat_id(user_id, thread_id)
         try:
             await bot.delete_message(chat_id=chat_id, message_id=msg_id)
         except Exception:

--- a/src/ccbot/handlers/status_polling.py
+++ b/src/ccbot/handlers/status_polling.py
@@ -116,7 +116,7 @@ async def status_poll_loop(bot: Bot) -> None:
                 ):
                     try:
                         await bot.unpin_all_forum_topic_messages(
-                            chat_id=user_id,
+                            chat_id=session_manager.resolve_chat_id(user_id, thread_id),
                             message_thread_id=thread_id,
                         )
                     except BadRequest as e:


### PR DESCRIPTION
## Summary

  Restore group chat_id routing for supergroup forum topics, which was
  removed in 26cb81f ("refactor: remove group_chat_ids, use user_id
  directly as chat_id").

  ## Problem

  When the bot runs in a Telegram supergroup with forum topics, all
  outgoing API calls (`send_message`, `edit_message_text`, `delete_message`,
  `edit_forum_topic`, etc.) use `user_id` as `chat_id`. However,
  `message_thread_id` only works when paired with the group's chat_id
  (a negative number like `-1003835331986`), not the user's personal ID.
  This causes every outbound message to fail with:



  Message thread not found


  This was originally fixed in 5afc111 and enhanced in a585990, but
  reverted in 26cb81f under the incorrect assumption that Telegram's
  bot API accepts `user_id` for forum topic messages.

  ## Approach

  Adds a separate `group_chat_ids` mapping persisted in `state.json`
  (composite key `"user_id:thread_id"` → group chat_id) with two methods:

  - `set_group_chat_id()` — called in `text_handler`, `callback_handler`,
    and `forward_command_handler` when the chat type is `group`/`supergroup`
  - `resolve_chat_id()` — returns the stored group chat_id when available,
    falls back to `user_id` for private chats

  All outgoing Telegram API calls now use `resolve_chat_id()` instead of
  raw `user_id`. No function signature changes, no data structure migration,
  no breaking changes for private chat users.

  Alternative to #22 — lighter patch that doesn't restructure
  `thread_bindings` or change function signatures.

  ## Files changed

  - `session.py` — `group_chat_ids` storage, `set_group_chat_id()`, `resolve_chat_id()`
  - `bot.py` — capture group chat_id on incoming messages, use `resolve_chat_id()` for `edit_forum_topic` and `safe_send`
  - `handlers/message_queue.py` — replace `chat_id=user_id` with `resolve_chat_id()` in all send/edit/delete calls
  - `handlers/interactive_ui.py` — `resolve_chat_id()` in `handle_interactive_ui` and `clear_interactive_msg`
  - `handlers/history.py` — `resolve_chat_id()` in `safe_send` calls
  - `handlers/status_polling.py` — `resolve_chat_id()` for `unpin_all_forum_topic_messages`

  ## Test plan

  - [x] `ruff check` — 0 issues
  - [x] `pyright` — 0 errors
  - [x] `pytest` — 192/192 passed
  - [ ] Manual: verify messages deliver to supergroup forum topics
  - [ ] Manual: verify private chat still works (no regression)

