### PR TITLE
feat: bidirectional image support between Telegram and Claude Code

### DIFF
--- a/src/ccbot/session_monitor.py
+++ b/src/ccbot/session_monitor.py
@@ -48,6 +48,7 @@ class NewMessage:
     tool_use_id: str | None = None
     role: str = "assistant"  # "user" or "assistant"
     tool_name: str | None = None  # For tool_use messages, the tool name
+    image_data: list[tuple[str, bytes]] | None = None  # From tool_result images
 
 
 class SessionMonitor:
@@ -327,7 +328,7 @@ class SessionMonitor:
                     self._pending_tools.pop(session_info.session_id, None)
 
                 for entry in parsed_entries:
-                    if not entry.text:
+                    if not entry.text and not entry.image_data:
                         continue
                     # Skip user messages unless show_user_messages is enabled
                     if entry.role == "user" and not config.show_user_messages:
@@ -341,6 +342,7 @@ class SessionMonitor:
                             tool_use_id=entry.tool_use_id,
                             role=entry.role,
                             tool_name=entry.tool_name,
+                            image_data=entry.image_data,
                         )
                     )
 


### PR DESCRIPTION
## Summary

Bidirectional image support for ccbot:

- **Claude Code → Telegram**: Extract base64-encoded images from `tool_result` content blocks in JSONL transcripts and send them as Telegram photos (single or media group)
- **Telegram → Claude Code**: Download photos sent by users, save to `~/.ccbot/images/`, and forward the file path to the Claude Code session for reading/analysis

## Changes

**Claude → Telegram (outbound images):**
- **transcript_parser.py** — new `extract_tool_result_images()` to decode base64 image blocks from tool results
- **session_monitor.py** — propagate `image_data` through `NewMessage`, allow image-only entries
- **message_sender.py** — new `send_photo()` function (single photo or media group)
- **message_queue.py** — `_send_task_images()` helper, plumb `image_data` through the queue and all send paths

**Telegram → Claude (inbound photos):**
- **bot.py** — new `photo_handler`: downloads highest-res photo, saves to `~/.ccbot/images/`, sends file path (with optional caption) to the bound tmux window. Registered as a handler before the unsupported-content catch-all.

## Context

Claude Code tools like `mcp__puppeteer__puppeteer_screenshot` and `Read` (for image files) return base64-encoded images in `tool_result` content blocks. Without the outbound change, those images are silently dropped.

For inbound, users can now share screenshots, diagrams, or photos directly in Telegram topics — Claude Code receives the file path and can read the image with its multimodal capabilities.

## Test plan

- [ ] Trigger a tool that returns a base64 image (e.g. puppeteer screenshot, Read on a PNG)
- [ ] Verify single image is sent as a photo in the correct topic
- [ ] Verify multiple images in one tool_result are sent as a media group
- [ ] Verify text-only tool results still work as before
- [ ] Verify image-only tool results (no text) are not dropped
- [ ] Send a photo in a bound topic → verify file saved to `~/.ccbot/images/`
- [ ] Send a photo with caption → verify caption + path forwarded to Claude
- [ ] Send a photo in an unbound topic → verify error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)