### PR TITLE
feat: add /model command support for switching AI models

### DIFF
--- a/src/ccbot/bot.py
+++ b/src/ccbot/bot.py
@@ -142,6 +142,7 @@ CC_COMMANDS: dict[str, str] = {
     "cost": "↗ Show token/cost usage",
     "help": "↗ Show Claude Code help",
     "memory": "↗ Edit CLAUDE.md",
+    "model": "↗ Switch AI model",
 }
 
 
@@ -476,6 +477,11 @@ async def forward_command_handler(
         if cc_slash.strip().lower() == "/clear":
             logger.info("Clearing session for window %s after /clear", display)
             session_manager.clear_window_session(wid)
+
+        # Interactive commands (e.g. /model) render a terminal-based UI
+        # with no JSONL tool_use entry.  The status poller already detects
+        # interactive UIs every 1s (status_polling.py), so no
+        # proactive detection needed here — the poller handles it.
     else:
         await safe_reply(update.message, f"❌ {message}")
 

--- a/src/ccbot/terminal_parser.py
+++ b/src/ccbot/terminal_parser.py
@@ -86,9 +86,14 @@ UI_PATTERNS: list[UIPattern] = [
     ),
     UIPattern(
         name="Settings",
-        top=(re.compile(r"^\s*Settings:.*tab to cycle"),),
+        top=(
+            re.compile(r"^\s*Settings:.*tab to cycle"),
+            re.compile(r"^\s*Select model"),
+        ),
         bottom=(
             re.compile(r"Esc to cancel"),
+            re.compile(r"Esc to exit"),
+            re.compile(r"Enter to confirm"),
             re.compile(r"^\s*Type to filter"),
         ),
     ),

--- a/tests/ccbot/conftest.py
+++ b/tests/ccbot/conftest.py
@@ -147,5 +147,22 @@ def sample_pane_status_line():
 
 
 @pytest.fixture
+def sample_pane_settings():
+    """Realistic Claude Code /model picker as captured from tmux."""
+    return (
+        " Select model\n"
+        " Switch between Claude models. Applies to this session and future Claude Code sessions.\n"
+        "\n"
+        "   1. Default (recommended)  Opus 4.6 · Most capable for complex work\n"
+        " ❯ 2. Sonnet                 Sonnet 4.6 · Best for everyday tasks\n"
+        "   3. Haiku                  Haiku 4.5 · Fastest for quick answers\n"
+        "\n"
+        " Use /fast to turn on Fast mode (Opus 4.6 only).\n"
+        "\n"
+        " Enter to confirm · Esc to exit\n"
+    )
+
+
+@pytest.fixture
 def sample_pane_no_ui():
     return "$ echo hello\nhello\n$\n"

--- a/tests/ccbot/handlers/test_interactive_ui.py
+++ b/tests/ccbot/handlers/test_interactive_ui.py
@@ -1,0 +1,111 @@
+"""Tests for interactive_ui — handle_interactive_ui and keyboard layout."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ccbot.handlers.interactive_ui import (
+    _build_interactive_keyboard,
+    handle_interactive_ui,
+)
+from ccbot.handlers.callback_data import (
+    CB_ASK_DOWN,
+    CB_ASK_ENTER,
+    CB_ASK_ESC,
+    CB_ASK_LEFT,
+    CB_ASK_RIGHT,
+    CB_ASK_SPACE,
+    CB_ASK_TAB,
+    CB_ASK_UP,
+)
+
+
+@pytest.fixture
+def mock_bot():
+    bot = AsyncMock()
+    sent_msg = MagicMock()
+    sent_msg.message_id = 999
+    bot.send_message.return_value = sent_msg
+    return bot
+
+
+@pytest.fixture
+def _clear_interactive_state():
+    """Ensure interactive state is clean before and after each test."""
+    from ccbot.handlers.interactive_ui import _interactive_mode, _interactive_msgs
+
+    _interactive_mode.clear()
+    _interactive_msgs.clear()
+    yield
+    _interactive_mode.clear()
+    _interactive_msgs.clear()
+
+
+@pytest.mark.usefixtures("_clear_interactive_state")
+class TestHandleInteractiveUI:
+    @pytest.mark.asyncio
+    async def test_handle_settings_ui_sends_keyboard(
+        self, mock_bot: AsyncMock, sample_pane_settings: str
+    ):
+        """handle_interactive_ui captures Settings pane, sends message with keyboard."""
+        window_id = "@5"
+        mock_window = MagicMock()
+        mock_window.window_id = window_id
+
+        with (
+            patch("ccbot.handlers.interactive_ui.tmux_manager") as mock_tmux,
+            patch("ccbot.handlers.interactive_ui.session_manager") as mock_sm,
+        ):
+            mock_tmux.find_window_by_id = AsyncMock(return_value=mock_window)
+            mock_tmux.capture_pane = AsyncMock(return_value=sample_pane_settings)
+            mock_sm.resolve_chat_id.return_value = 100
+
+            result = await handle_interactive_ui(
+                mock_bot, user_id=1, window_id=window_id, thread_id=42
+            )
+
+        assert result is True
+        mock_bot.send_message.assert_called_once()
+        call_kwargs = mock_bot.send_message.call_args
+        assert call_kwargs.kwargs["chat_id"] == 100
+        assert call_kwargs.kwargs["message_thread_id"] == 42
+        assert call_kwargs.kwargs["reply_markup"] is not None
+
+    @pytest.mark.asyncio
+    async def test_handle_no_ui_returns_false(self, mock_bot: AsyncMock):
+        """Returns False when no interactive UI detected in pane."""
+        window_id = "@5"
+        mock_window = MagicMock()
+        mock_window.window_id = window_id
+
+        with (
+            patch("ccbot.handlers.interactive_ui.tmux_manager") as mock_tmux,
+            patch("ccbot.handlers.interactive_ui.session_manager"),
+        ):
+            mock_tmux.find_window_by_id = AsyncMock(return_value=mock_window)
+            mock_tmux.capture_pane = AsyncMock(return_value="$ echo hello\nhello\n$\n")
+
+            result = await handle_interactive_ui(
+                mock_bot, user_id=1, window_id=window_id, thread_id=42
+            )
+
+        assert result is False
+        mock_bot.send_message.assert_not_called()
+
+
+class TestKeyboardLayoutForSettings:
+    def test_settings_keyboard_includes_all_nav_keys(self):
+        """Settings keyboard includes Tab, arrows (not vertical_only), Space, Esc, Enter."""
+        keyboard = _build_interactive_keyboard("@5", ui_name="Settings")
+        # Flatten all callback data values
+        all_cb_data = [
+            btn.callback_data for row in keyboard.inline_keyboard for btn in row
+        ]
+        assert any(CB_ASK_TAB in d for d in all_cb_data if d)
+        assert any(CB_ASK_SPACE in d for d in all_cb_data if d)
+        assert any(CB_ASK_UP in d for d in all_cb_data if d)
+        assert any(CB_ASK_DOWN in d for d in all_cb_data if d)
+        assert any(CB_ASK_LEFT in d for d in all_cb_data if d)
+        assert any(CB_ASK_RIGHT in d for d in all_cb_data if d)
+        assert any(CB_ASK_ESC in d for d in all_cb_data if d)
+        assert any(CB_ASK_ENTER in d for d in all_cb_data if d)

--- a/tests/ccbot/handlers/test_status_polling.py
+++ b/tests/ccbot/handlers/test_status_polling.py
@@ -1,0 +1,141 @@
+"""Tests for status_polling — Settings UI detection via the poller path.
+
+Simulates the user workflow: /model is sent to Claude Code, the Settings
+model picker renders in the terminal, and the status poller detects it
+on its next 1s tick.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ccbot.handlers.status_polling import update_status_message
+
+
+@pytest.fixture
+def mock_bot():
+    bot = AsyncMock()
+    sent_msg = MagicMock()
+    sent_msg.message_id = 999
+    bot.send_message.return_value = sent_msg
+    return bot
+
+
+@pytest.fixture
+def _clear_interactive_state():
+    """Ensure interactive state is clean before and after each test."""
+    from ccbot.handlers.interactive_ui import _interactive_mode, _interactive_msgs
+
+    _interactive_mode.clear()
+    _interactive_msgs.clear()
+    yield
+    _interactive_mode.clear()
+    _interactive_msgs.clear()
+
+
+@pytest.mark.usefixtures("_clear_interactive_state")
+class TestStatusPollerSettingsDetection:
+    """Simulate the status poller detecting a Settings UI in the terminal.
+
+    This is the actual code path for /model: no JSONL tool_use entry exists,
+    so the status poller (update_status_message) is the only detector.
+    """
+
+    @pytest.mark.asyncio
+    async def test_settings_ui_detected_and_keyboard_sent(
+        self, mock_bot: AsyncMock, sample_pane_settings: str
+    ):
+        """Poller captures Settings pane → handle_interactive_ui sends keyboard."""
+        window_id = "@5"
+        mock_window = MagicMock()
+        mock_window.window_id = window_id
+
+        with (
+            patch("ccbot.handlers.status_polling.tmux_manager") as mock_tmux,
+            patch(
+                "ccbot.handlers.status_polling.handle_interactive_ui",
+                new_callable=AsyncMock,
+            ) as mock_handle_ui,
+        ):
+            mock_tmux.find_window_by_id = AsyncMock(return_value=mock_window)
+            mock_tmux.capture_pane = AsyncMock(return_value=sample_pane_settings)
+            mock_handle_ui.return_value = True
+
+            await update_status_message(
+                mock_bot, user_id=1, window_id=window_id, thread_id=42
+            )
+
+            mock_handle_ui.assert_called_once_with(mock_bot, 1, window_id, 42)
+
+    @pytest.mark.asyncio
+    async def test_normal_pane_no_interactive_ui(self, mock_bot: AsyncMock):
+        """Normal pane text → no handle_interactive_ui call, just status check."""
+        window_id = "@5"
+        mock_window = MagicMock()
+        mock_window.window_id = window_id
+        normal_pane = (
+            "some output\n"
+            "✻ Reading file\n"
+            "──────────────────────────────────────\n"
+            "❯ \n"
+            "──────────────────────────────────────\n"
+            "  [Opus 4.6] Context: 50%\n"
+        )
+
+        with (
+            patch("ccbot.handlers.status_polling.tmux_manager") as mock_tmux,
+            patch(
+                "ccbot.handlers.status_polling.handle_interactive_ui",
+                new_callable=AsyncMock,
+            ) as mock_handle_ui,
+            patch(
+                "ccbot.handlers.status_polling.enqueue_status_update",
+                new_callable=AsyncMock,
+            ),
+        ):
+            mock_tmux.find_window_by_id = AsyncMock(return_value=mock_window)
+            mock_tmux.capture_pane = AsyncMock(return_value=normal_pane)
+
+            await update_status_message(
+                mock_bot, user_id=1, window_id=window_id, thread_id=42
+            )
+
+            mock_handle_ui.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_settings_ui_end_to_end_sends_telegram_keyboard(
+        self, mock_bot: AsyncMock, sample_pane_settings: str
+    ):
+        """Full end-to-end: poller → is_interactive_ui → handle_interactive_ui
+        → bot.send_message with keyboard.
+
+        Uses real handle_interactive_ui (not mocked) to verify the full path.
+        """
+        window_id = "@5"
+        mock_window = MagicMock()
+        mock_window.window_id = window_id
+
+        with (
+            patch("ccbot.handlers.status_polling.tmux_manager") as mock_tmux_poll,
+            patch("ccbot.handlers.interactive_ui.tmux_manager") as mock_tmux_ui,
+            patch("ccbot.handlers.interactive_ui.session_manager") as mock_sm,
+        ):
+            mock_tmux_poll.find_window_by_id = AsyncMock(return_value=mock_window)
+            mock_tmux_poll.capture_pane = AsyncMock(return_value=sample_pane_settings)
+            mock_tmux_ui.find_window_by_id = AsyncMock(return_value=mock_window)
+            mock_tmux_ui.capture_pane = AsyncMock(return_value=sample_pane_settings)
+            mock_sm.resolve_chat_id.return_value = 100
+
+            await update_status_message(
+                mock_bot, user_id=1, window_id=window_id, thread_id=42
+            )
+
+            # Verify bot.send_message was called with keyboard
+            mock_bot.send_message.assert_called_once()
+            call_kwargs = mock_bot.send_message.call_args.kwargs
+            assert call_kwargs["chat_id"] == 100
+            assert call_kwargs["message_thread_id"] == 42
+            keyboard = call_kwargs["reply_markup"]
+            assert keyboard is not None
+            # Verify the message text contains model picker content
+            assert "Select model" in call_kwargs["text"]

--- a/tests/ccbot/test_forward_command.py
+++ b/tests/ccbot/test_forward_command.py
@@ -1,0 +1,104 @@
+"""Tests for forward_command_handler — command forwarding to Claude Code."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_update(text: str, user_id: int = 1, thread_id: int = 42) -> MagicMock:
+    """Build a minimal mock Update with message text in a forum topic."""
+    update = MagicMock()
+    update.effective_user = MagicMock()
+    update.effective_user.id = user_id
+    update.message = MagicMock()
+    update.message.text = text
+    update.message.message_thread_id = thread_id
+    update.message.chat = MagicMock()
+    update.message.chat.send_action = AsyncMock()
+    update.effective_chat = MagicMock()
+    update.effective_chat.type = "supergroup"
+    update.effective_chat.id = 100
+    return update
+
+
+def _make_context() -> MagicMock:
+    """Build a minimal mock context."""
+    context = MagicMock()
+    context.bot = AsyncMock()
+    context.user_data = {}
+    return context
+
+
+class TestForwardCommand:
+    @pytest.mark.asyncio
+    async def test_model_sends_command_to_tmux(self):
+        """/model → send_to_window called with "/model"."""
+        update = _make_update("/model")
+        context = _make_context()
+
+        with (
+            patch("ccbot.bot.is_user_allowed", return_value=True),
+            patch("ccbot.bot._get_thread_id", return_value=42),
+            patch("ccbot.bot.session_manager") as mock_sm,
+            patch("ccbot.bot.tmux_manager") as mock_tmux,
+            patch("ccbot.bot.safe_reply", new_callable=AsyncMock),
+        ):
+            mock_sm.resolve_window_for_thread.return_value = "@5"
+            mock_sm.get_display_name.return_value = "project"
+            mock_tmux.find_window_by_id = AsyncMock(return_value=MagicMock())
+            mock_sm.send_to_window = AsyncMock(return_value=(True, "ok"))
+
+            from ccbot.bot import forward_command_handler
+
+            await forward_command_handler(update, context)
+
+            mock_sm.send_to_window.assert_called_once_with("@5", "/model")
+
+    @pytest.mark.asyncio
+    async def test_cost_sends_command_to_tmux(self):
+        """/cost → send_to_window called with "/cost"."""
+        update = _make_update("/cost")
+        context = _make_context()
+
+        with (
+            patch("ccbot.bot.is_user_allowed", return_value=True),
+            patch("ccbot.bot._get_thread_id", return_value=42),
+            patch("ccbot.bot.session_manager") as mock_sm,
+            patch("ccbot.bot.tmux_manager") as mock_tmux,
+            patch("ccbot.bot.safe_reply", new_callable=AsyncMock),
+        ):
+            mock_sm.resolve_window_for_thread.return_value = "@5"
+            mock_sm.get_display_name.return_value = "project"
+            mock_tmux.find_window_by_id = AsyncMock(return_value=MagicMock())
+            mock_sm.send_to_window = AsyncMock(return_value=(True, "ok"))
+
+            from ccbot.bot import forward_command_handler
+
+            await forward_command_handler(update, context)
+
+            mock_sm.send_to_window.assert_called_once_with("@5", "/cost")
+
+    @pytest.mark.asyncio
+    async def test_clear_clears_session(self):
+        """/clear → send_to_window + clear_window_session."""
+        update = _make_update("/clear")
+        context = _make_context()
+
+        with (
+            patch("ccbot.bot.is_user_allowed", return_value=True),
+            patch("ccbot.bot._get_thread_id", return_value=42),
+            patch("ccbot.bot.session_manager") as mock_sm,
+            patch("ccbot.bot.tmux_manager") as mock_tmux,
+            patch("ccbot.bot.safe_reply", new_callable=AsyncMock),
+        ):
+            mock_sm.resolve_window_for_thread.return_value = "@5"
+            mock_sm.get_display_name.return_value = "project"
+            mock_tmux.find_window_by_id = AsyncMock(return_value=MagicMock())
+            mock_sm.send_to_window = AsyncMock(return_value=(True, "ok"))
+
+            from ccbot.bot import forward_command_handler
+
+            await forward_command_handler(update, context)
+
+            mock_sm.send_to_window.assert_called_once_with("@5", "/clear")
+            mock_sm.clear_window_session.assert_called_once_with("@5")

--- a/tests/ccbot/test_terminal_parser.py
+++ b/tests/ccbot/test_terminal_parser.py
@@ -120,6 +120,45 @@ class TestExtractInteractiveContent:
         assert result.name == "Settings"
         assert "Settings:" in result.content
 
+    def test_settings_model_picker(self, sample_pane_settings: str):
+        result = extract_interactive_content(sample_pane_settings)
+        assert result is not None
+        assert result.name == "Settings"
+        assert "Select model" in result.content
+        assert "Sonnet" in result.content
+        assert "Enter to confirm" in result.content
+
+    def test_settings_esc_to_cancel_bottom(self):
+        pane = (
+            "  Settings: press tab to cycle\n"
+            "  ─────\n"
+            "  Model\n"
+            "  ─────\n"
+            "  ● claude-sonnet-4-20250514\n"
+            "  ○ claude-opus-4-20250514\n"
+            "  Esc to cancel\n"
+        )
+        result = extract_interactive_content(pane)
+        assert result is not None
+        assert result.name == "Settings"
+        assert "Esc to cancel" in result.content
+
+    def test_settings_esc_to_exit_bottom(self):
+        pane = (
+            "  Settings: press tab to cycle\n"
+            "  ─────\n"
+            "  Model\n"
+            "  ─────\n"
+            "  ● Default (Opus 4.6)\n"
+            "  ○ claude-sonnet-4-20250514\n"
+            "\n"
+            "  Enter to confirm · Esc to exit\n"
+        )
+        result = extract_interactive_content(pane)
+        assert result is not None
+        assert result.name == "Settings"
+        assert "Enter to confirm" in result.content
+
     @pytest.mark.parametrize(
         "pane",
         [
@@ -144,6 +183,9 @@ class TestIsInteractiveUI:
 
     def test_false_when_no_ui(self, sample_pane_no_ui: str):
         assert is_interactive_ui(sample_pane_no_ui) is False
+
+    def test_settings_is_interactive(self, sample_pane_settings: str):
+        assert is_interactive_ui(sample_pane_settings) is True
 
     def test_false_for_empty_string(self):
         assert is_interactive_ui("") is False


### PR DESCRIPTION
## Summary
- Add `/model` to `CC_COMMANDS` so it appears in the Telegram bot menu and gets forwarded to Claude Code via tmux
- Extend `Settings` UI detection patterns in `terminal_parser.py` to recognise the new "Select model" picker (`top`) and "Enter to confirm" / "Esc to exit" (`bottom`), so the status poller surfaces the interactive keyboard in Telegram
- Add comment in `forward_command_handler` noting that interactive commands like `/model` are handled by the status poller (no proactive detection needed)

## Test plan
- [x] New tests for terminal parser: model picker detection (`test_settings_model_picker`, `test_settings_esc_to_exit_bottom`, `is_interactive_ui` for Settings)
- [x] New tests for interactive_ui handler: Settings keyboard sent, no-UI returns false, keyboard includes all nav keys
- [x] New tests for status_polling: poller detects Settings UI, normal pane skips, end-to-end keyboard delivery
- [x] New tests for forward_command_handler: `/model`, `/cost`, `/clear` forwarding
- [x] All 215 tests pass, ruff + pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)