### PR TITLE
feat: add CCBOT_SHOW_HIDDEN_DIRS option for directory browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ ALLOWED_USERS=your_telegram_user_id
 | `TMUX_SESSION_NAME`     | `ccbot`    | Tmux session name                                |
 | `CLAUDE_COMMAND`        | `claude`   | Command to run in new windows                    |
 | `MONITOR_POLL_INTERVAL` | `2.0`      | Polling interval in seconds                      |
+| `CCBOT_SHOW_HIDDEN_DIRS` | `false` | Show hidden (dot) directories in directory browser |
 
 > If running on a VPS where there's no interactive terminal to approve permissions, consider:
 >

--- a/src/ccbot/config.py
+++ b/src/ccbot/config.py
@@ -85,6 +85,11 @@ class Config:
         # When True, user messages are shown with a 👤 prefix
         self.show_user_messages = True
 
+        # Show hidden (dot) directories in directory browser
+        self.show_hidden_dirs = (
+            os.getenv("CCBOT_SHOW_HIDDEN_DIRS", "").lower() == "true"
+        )
+
         logger.debug(
             "Config initialized: dir=%s, token=%s..., allowed_users=%d, "
             "tmux_session=%s, claude_projects_path=%s",

--- a/src/ccbot/handlers/directory_browser.py
+++ b/src/ccbot/handlers/directory_browser.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
+from ..config import config
 from .callback_data import (
     CB_DIR_CANCEL,
     CB_DIR_CONFIRM,
@@ -118,7 +119,8 @@ def build_directory_browser(
             [
                 d.name
                 for d in path.iterdir()
-                if d.is_dir() and not d.name.startswith(".")
+                if d.is_dir()
+                and (config.show_hidden_dirs or not d.name.startswith("."))
             ]
         )
     except (PermissionError, OSError):


### PR DESCRIPTION
Love this tool — thanks for building it! 🙌

## Summary

The directory browser filters out dot-directories by default. Some users need to navigate into hidden directories (e.g. `.config`, `.claude`) when selecting a working directory.

This adds a `CCBOT_SHOW_HIDDEN_DIRS=true` env var to optionally show them, defaulting to the current behavior (hidden).

## Changes

- `config.py`: Add `show_hidden_dirs` config from `CCBOT_SHOW_HIDDEN_DIRS` env var
- `directory_browser.py`: Conditionally filter dot-directories based on config
- `README.md`: Document the new env var in the Optional table

Happy to discuss or adjust anything!