### PR TITLE
fix: prevent Claude Code from overriding tmux window names

### DIFF
--- a/src/ccbot/tmux_manager.py
+++ b/src/ccbot/tmux_manager.py
@@ -389,6 +389,9 @@ class TmuxManager:
 
                 wid = window.window_id or ""
 
+                # Prevent Claude Code from overriding window name
+                window.set_window_option("allow-rename", "off")
+
                 # Start Claude Code if requested
                 if start_claude:
                     pane = window.active_pane


### PR DESCRIPTION
## Summary

- Claude Code sets the terminal title to "claude" on startup via escape sequences, which overwrites our custom window names and makes all windows indistinguishable in tmux
- Set `allow-rename off` per-window in `create_window()` so the bot-assigned name is preserved regardless of what the child process does

## Changes

One-line addition in `tmux_manager.py`: call `window.set_window_option("allow-rename", "off")` right after window creation, before starting Claude Code.

## Test plan

- [x] Create a new session via the directory browser — verify the window name matches the selected directory
- [ ] Confirm the window name stays unchanged after Claude Code finishes initializing
- [ ] Verify existing sessions (created before this change) still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)