### PR TITLE
feat: add voice message transcription support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,16 @@ CLAUDE_COMMAND=claude
 
 # Monitor polling interval in seconds (optional, defaults to 2.0)
 MONITOR_POLL_INTERVAL=2.0
+
+# Voice transcription (optional, defaults to "local")
+# "local" = faster-whisper on CPU (free, requires ffmpeg + uv pip install -e ".[voice]")
+# "openai" = OpenAI Whisper API (requires OPENAI_API_KEY + uv pip install -e ".[voice-openai]")
+# "off" = disable voice messages
+CCBOT_WHISPER_BACKEND=local
+
+# Whisper model size (optional, defaults to "base")
+# Options: tiny, base, small, medium, large-v3
+CCBOT_WHISPER_MODEL=base
+
+# OpenAI API key (required only if CCBOT_WHISPER_BACKEND=openai)
+# OPENAI_API_KEY=sk-...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,12 @@ dev = [
     "pytest-cov>=6.0",
     "ruff>=0.8.0",
 ]
+voice = [
+    "faster-whisper>=1.0.0",
+]
+voice-openai = [
+    "openai>=1.0.0",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/src/ccbot/bot.py
+++ b/src/ccbot/bot.py
@@ -12,8 +12,10 @@ Core responsibilities:
     Unbound topics trigger the directory browser to create a new session.
   - Photo handling: photos sent by user are downloaded and forwarded
     to Claude Code as file paths (photo_handler).
+  - Voice handling: voice messages are transcribed via Whisper and
+    forwarded as text to Claude Code (voice_handler).
   - Automatic cleanup: closing a topic kills the associated window
-    (topic_closed_handler). Unsupported content (stickers, voice, etc.)
+    (topic_closed_handler). Unsupported content (stickers, etc.)
     is rejected with a warning (unsupported_content_handler).
   - Bot lifecycle management: post_init, post_shutdown, create_bot.
 
@@ -124,6 +126,7 @@ from .screenshot import text_to_image
 from .session import session_manager
 from .session_monitor import NewMessage, SessionMonitor
 from .terminal_parser import extract_bash_output
+from .transcribe import TranscriptionDisabled, TranscriptionError, transcribe
 from .tmux_manager import tmux_manager
 from .utils import ccbot_dir
 
@@ -499,7 +502,7 @@ async def unsupported_content_handler(
     logger.debug("Unsupported content from user %d", user.id)
     await safe_reply(
         update.message,
-        "⚠ Only text messages are supported. Images, stickers, voice, and other media cannot be forwarded to Claude Code.",
+        "⚠ Only text, photo, and voice messages are supported. Stickers and other media cannot be forwarded to Claude Code.",
     )
 
 
@@ -507,8 +510,12 @@ async def unsupported_content_handler(
 _IMAGES_DIR = ccbot_dir() / "images"
 _IMAGES_DIR.mkdir(parents=True, exist_ok=True)
 
+# --- Audio directory for incoming voice messages ---
+_AUDIO_DIR = ccbot_dir() / "audio"
+_AUDIO_DIR.mkdir(parents=True, exist_ok=True)
 
-async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+
+async def photo_handler(update: Update, _context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle photos sent by the user: download and forward path to Claude Code."""
     user = update.effective_user
     if not user or not is_user_allowed(user.id):
@@ -577,6 +584,83 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
 
     # Confirm to user
     await safe_reply(update.message, "📷 Image sent to Claude Code.")
+
+
+async def voice_handler(update: Update, _context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle voice messages: download, transcribe, and forward text to Claude Code."""
+    user = update.effective_user
+    if not user or not is_user_allowed(user.id):
+        if update.message:
+            await safe_reply(update.message, "You are not authorized to use this bot.")
+        return
+
+    if not update.message or not update.message.voice:
+        return
+
+    chat = update.message.chat
+    thread_id = _get_thread_id(update)
+    if chat.type in ("group", "supergroup") and thread_id is not None:
+        session_manager.set_group_chat_id(user.id, thread_id, chat.id)
+
+    if thread_id is None:
+        await safe_reply(
+            update.message,
+            "❌ Please use a named topic. Create a new topic to start a session.",
+        )
+        return
+
+    wid = session_manager.get_window_for_thread(user.id, thread_id)
+    if wid is None:
+        await safe_reply(
+            update.message,
+            "❌ No session bound to this topic. Send a text message first to create one.",
+        )
+        return
+
+    w = await tmux_manager.find_window_by_id(wid)
+    if not w:
+        display = session_manager.get_display_name(wid)
+        session_manager.unbind_thread(user.id, thread_id)
+        await safe_reply(
+            update.message,
+            f"❌ Window '{display}' no longer exists. Binding removed.\n"
+            "Send a message to start a new session.",
+        )
+        return
+
+    # Download the voice file
+    voice = update.message.voice
+    tg_file = await voice.get_file()
+    filename = f"{int(time.time())}_{voice.file_unique_id}.ogg"
+    file_path = _AUDIO_DIR / filename
+    await tg_file.download_to_drive(file_path)
+
+    # Transcribe
+    try:
+        await update.message.chat.send_action(ChatAction.TYPING)
+        text = await transcribe(file_path)
+    except TranscriptionDisabled as e:
+        await safe_reply(update.message, f"🎤 Voice not available: {e}")
+        return
+    except TranscriptionError as e:
+        await safe_reply(update.message, f"❌ Transcription failed: {e}")
+        return
+    except Exception:
+        logger.exception("Unexpected transcription error")
+        await safe_reply(update.message, "❌ Transcription failed unexpectedly.")
+        return
+
+    # Clean up audio file
+    file_path.unlink(missing_ok=True)
+
+    # Show transcription to user
+    await safe_reply(update.message, f'🎤 "{text}"')
+
+    # Forward to Claude Code
+    clear_status_msg_info(user.id, thread_id)
+    success, message = await session_manager.send_to_window(wid, text)
+    if not success:
+        await safe_reply(update.message, f"❌ {message}")
 
 
 # Active bash capture tasks: (user_id, thread_id) → asyncio.Task
@@ -1593,7 +1677,9 @@ def create_bot() -> Application:
     )
     # Photos: download and forward file path to Claude Code
     application.add_handler(MessageHandler(filters.PHOTO, photo_handler))
-    # Catch-all: non-text content (stickers, voice, etc.)
+    # Voice messages: transcribe and forward text to Claude Code
+    application.add_handler(MessageHandler(filters.VOICE, voice_handler))
+    # Catch-all: non-text content (stickers, etc.)
     application.add_handler(
         MessageHandler(
             ~filters.COMMAND & ~filters.TEXT & ~filters.StatusUpdate.ALL,

--- a/src/ccbot/config.py
+++ b/src/ccbot/config.py
@@ -90,6 +90,17 @@ class Config:
             os.getenv("CCBOT_SHOW_HIDDEN_DIRS", "").lower() == "true"
         )
 
+        # Voice transcription settings
+        self.whisper_backend: str = os.getenv("CCBOT_WHISPER_BACKEND", "local").lower()
+        if self.whisper_backend not in ("local", "openai", "off"):
+            logger.warning(
+                "Unknown CCBOT_WHISPER_BACKEND=%r, defaulting to 'off'",
+                self.whisper_backend,
+            )
+            self.whisper_backend = "off"
+        self.whisper_model: str = os.getenv("CCBOT_WHISPER_MODEL", "base")
+        self.openai_api_key: str = os.getenv("OPENAI_API_KEY", "")
+
         logger.debug(
             "Config initialized: dir=%s, token=%s..., allowed_users=%d, "
             "tmux_session=%s, claude_projects_path=%s",

--- a/src/ccbot/transcribe.py
+++ b/src/ccbot/transcribe.py
@@ -1,0 +1,131 @@
+"""Voice message transcription — converts audio to text via Whisper.
+
+Supports two backends selected by CCBOT_WHISPER_BACKEND:
+  - "local": Uses faster-whisper (CPU, no API key needed, requires ffmpeg)
+  - "openai": Uses OpenAI Whisper API (requires OPENAI_API_KEY)
+  - "off": Voice messages are rejected
+
+Key function: transcribe() — async, returns transcribed text.
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any
+
+from .config import config
+
+logger = logging.getLogger(__name__)
+
+# Lazy-loaded backends
+_local_model: Any = None
+_openai_client: Any = None
+
+
+class TranscriptionError(Exception):
+    """Raised when transcription fails."""
+
+
+class TranscriptionDisabled(Exception):
+    """Raised when voice transcription is disabled or unavailable."""
+
+
+def _get_local_model() -> Any:
+    """Lazy-load the faster-whisper model (downloads on first use)."""
+    global _local_model
+    if _local_model is not None:
+        return _local_model
+    try:
+        from faster_whisper import WhisperModel  # type: ignore[import-untyped]
+    except ImportError:
+        raise TranscriptionDisabled(
+            "faster-whisper is not installed. "
+            'Install with: uv pip install -e ".[voice]"\n'
+            "Or set CCBOT_WHISPER_BACKEND=off to disable voice messages."
+        )
+    logger.info(
+        "Loading faster-whisper model '%s' (may download on first use)...",
+        config.whisper_model,
+    )
+    _local_model = WhisperModel(config.whisper_model, device="cpu", compute_type="int8")
+    logger.info("faster-whisper model loaded successfully")
+    return _local_model
+
+
+def _transcribe_local_sync(file_path: Path) -> str:
+    """Synchronous transcription using faster-whisper (CPU-bound)."""
+    model = _get_local_model()
+    segments, info = model.transcribe(str(file_path), beam_size=5)
+    text = " ".join(segment.text.strip() for segment in segments)
+    if not text.strip():
+        raise TranscriptionError("Transcription produced empty text")
+    logger.info(
+        "Transcribed %s: language=%s, duration=%.1fs, text_len=%d",
+        file_path.name,
+        info.language,
+        info.duration,
+        len(text),
+    )
+    return text.strip()
+
+
+async def _transcribe_openai(file_path: Path) -> str:
+    """Async transcription using OpenAI Whisper API."""
+    global _openai_client
+    if _openai_client is None:
+        try:
+            from openai import AsyncOpenAI  # type: ignore[import-untyped]
+        except ImportError:
+            raise TranscriptionDisabled(
+                "openai package is not installed. "
+                'Install with: uv pip install -e ".[voice-openai]"\n'
+                "Or set CCBOT_WHISPER_BACKEND=local to use local transcription."
+            )
+        if not config.openai_api_key:
+            raise TranscriptionDisabled(
+                "OPENAI_API_KEY is required for the openai whisper backend."
+            )
+        _openai_client = AsyncOpenAI(api_key=config.openai_api_key)
+
+    with open(file_path, "rb") as audio_file:
+        transcript = await _openai_client.audio.transcriptions.create(
+            model="whisper-1",
+            file=audio_file,
+        )
+    text = transcript.text.strip()
+    if not text:
+        raise TranscriptionError("Transcription produced empty text")
+    logger.info(
+        "Transcribed %s via OpenAI: text_len=%d",
+        file_path.name,
+        len(text),
+    )
+    return text
+
+
+async def transcribe(file_path: Path) -> str:
+    """Transcribe an audio file to text using the configured backend.
+
+    Args:
+        file_path: Path to the audio file (OGG/Opus from Telegram).
+
+    Returns:
+        Transcribed text string.
+
+    Raises:
+        TranscriptionDisabled: Backend is off or dependency missing.
+        TranscriptionError: Transcription failed or produced empty text.
+    """
+    backend = config.whisper_backend
+
+    if backend == "off":
+        raise TranscriptionDisabled("Voice transcription is disabled.")
+
+    if backend == "local":
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, _transcribe_local_sync, file_path)
+
+    if backend == "openai":
+        return await _transcribe_openai(file_path)
+
+    raise TranscriptionDisabled(f"Unknown backend: {backend}")


### PR DESCRIPTION
## Summary

- Transcribe Telegram voice messages via Whisper and forward the text to Claude Code
- Two backends: `local` (faster-whisper, CPU, free) or `openai` (Whisper API)
- Configurable via `CCBOT_WHISPER_BACKEND` (local/openai/off) and `CCBOT_WHISPER_MODEL`
- Audio files are cleaned up after transcription

## Changes

- **`src/ccbot/transcribe.py`** — New module with lazy-loaded local and OpenAI backends
- **`src/ccbot/bot.py`** — `voice_handler` (download → transcribe → show → forward), updated `photo_handler` signature, registered `VOICE` filter
- **`src/ccbot/config.py`** — New config: `CCBOT_WHISPER_BACKEND`, `CCBOT_WHISPER_MODEL`, `OPENAI_API_KEY`
- **`pyproject.toml`** — Optional `[voice]` and `[voice-openai]` dependency groups
- **`.env.example`** — Documented new env vars

## Setup

```bash
# Local backend (default, free)
uv pip install -e ".[voice]"
sudo apt install ffmpeg  # required by faster-whisper

# OR OpenAI backend
uv pip install -e ".[voice-openai]"
# Set OPENAI_API_KEY in .env
# Set CCBOT_WHISPER_BACKEND=openai in .env
```

## Test plan

- [x] Send voice message in bound topic → transcription shown and forwarded to Claude
- [x] Verify audio file is deleted after transcription
- [ ] Test with `CCBOT_WHISPER_BACKEND=off` → graceful rejection
- [ ] Test with missing `faster-whisper` dependency → helpful error message
- [ ] Test with `openai` backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)