### PR TITLE
fix crash due to dependency conflict.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "libtmux>=0.37.0",
     "Pillow>=10.0.0",
     "aiofiles>=24.0.0",
-    "telegramify-markdown>=0.5.0",
+    "telegramify-markdown>=0.5.0,<1.0.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
As the log shows, ccbot is crashing because of recent release of package `telegramify-markdown`.
This patch upgrades pyproject.toml: telegramify-markdown>=0.5.0,<1.0.0 to avoid  crash due to package version conflict.


```bash
❯ uv tool uninstall ccbot;uv tool install ccbot ; ccbot
Uninstalled 1 executable: ccbot
Resolved 19 packages in 6ms
Installed 19 packages in 10ms
 + aiofiles==25.1.0
 + anyio==4.12.1
 + ccbot==1.6.9
 + certifi==2026.2.25
 + click==8.3.1
 + h11==0.16.0
 + httpcore==1.0.9
 + httpx==0.28.1
 + idna==3.11
 + libtmux==0.55.0
 + pillow==12.1.1
 + pyromark==0.9.8
 + pyte==0.8.2
 + python-dotenv==1.2.2
 + python-telegram-bot==22.6
 + structlog==25.5.0
 + telegramify-markdown==1.0.0
 + typing-extensions==4.15.0
 + wcwidth==0.6.0
Installed 1 executable: ccbot
10:21:00 [debug    ] Loaded env from /Users/USER/.ccbot/.env
10:21:00 [debug    ] Config initialized: dir=/Users/USER/.ccbot, token=xxxx..., allowed_users=1, tmux_session=ccbot
10:21:00 [info     ] Allowed users: {xxxx}             
10:21:00 [info     ] Claude projects path: /Users/USER/.claude/projects
10:21:00 [info     ] Tmux session 'ccbot' ready              
10:21:00 [info     ] Starting Telegram bot...                
Traceback (most recent call last):
  File "/Users/USER/.local/bin/ccbot", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/USER/.local/share/uv/tools/ccbot/lib/python3.14/site-packages/ccbot/main.py", line 112, in main
    cli()
    ~~~^^
  File "/Users/USER/.local/share/uv/tools/ccbot/lib/python3.14/site-packages/click/core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/USER/.local/share/uv/tools/ccbot/lib/python3.14/site-packages/click/core.py", line 1406, in main
    rv = self.invoke(ctx)
  File "/Users/USER/.local/share/uv/tools/ccbot/lib/python3.14/site-packages/click/core.py", line 1851, in invoke
    rv = super().invoke(ctx)
  File "/Users/USER/.local/share/uv/tools/ccbot/lib/python3.14/site-packages/click/core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/USER/.local/share/uv/tools/ccbot/lib/python3.14/site-packages/click/core.py", line 824, in invoke
    return callback(*args, **kwargs)
  File "/Users/USER/.local/share/uv/tools/ccbot/lib/python3.14/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/USER/.local/share/uv/tools/ccbot/lib/python3.14/site-packages/ccbot/cli.py", line 53, in cli
    ctx.invoke(run_cmd)
    ~~~~~~~~~~^^^^^^^^^
  File "/Users/USER/.local/share/uv/tools/ccbot/lib/python3.14/site-packages/click/core.py", line 824, in invoke
    return callback(*args, **kwargs)
  File "/Users/USER/.local/share/uv/tools/ccbot/lib/python3.14/site-packages/ccbot/cli.py", line 188, in run_cmd
    run_bot()
    ~~~~~~~^^
  File "/Users/USER/.local/share/uv/tools/ccbot/lib/python3.14/site-packages/ccbot/main.py", line 98, in run_bot
    from .bot import create_bot
  File "/Users/USER/.local/share/uv/tools/ccbot/lib/python3.14/site-packages/ccbot/bot.py", line 111, in <module>
    from .handlers.directory_callbacks import handle_directory_callback
  File "/Users/USER/.local/share/uv/tools/ccbot/lib/python3.14/site-packages/ccbot/handlers/directory_callbacks.py", line 49, in <module>
    from .message_sender import safe_edit, safe_send
  File "/Users/USER/.local/share/uv/tools/ccbot/lib/python3.14/site-packages/ccbot/handlers/message_sender.py", line 24, in <module>
    from ..markdown_v2 import convert_markdown
  File "/Users/USER/.local/share/uv/tools/ccbot/lib/python3.14/site-packages/ccbot/markdown_v2.py", line 13, in <module>
    import mistletoe
ModuleNotFoundError: No module named 'mistletoe'

~ via 🥟 v1.3.9 
❯ uv tool uninstall ccbot; uv tool install --from "git+https://github.com/six-ddc/ccmux.git" ccbot --with "telegramify-markdown==0.5.4" ;  ccbot
Uninstalled 1 executable: ccbot
    Updated https://github.com/six-ddc/ccmux.git (aebc7a925b32b3530b946f523612d9eb007cc47b)
Resolved 16 packages in 9ms
Installed 16 packages in 8ms
 + aiofiles==25.1.0
 + aiolimiter==1.2.1
 + anyio==4.12.1
 + ccbot==0.1.0 (from git+https://github.com/six-ddc/ccmux.git@aebc7a925b32b3530b946f523612d9eb007cc47b)
 + certifi==2026.2.25
 + h11==0.16.0
 + httpcore==1.0.9
 + httpx==0.28.1
 + idna==3.11
 + libtmux==0.55.0
 + mistletoe==1.4.0
 + pillow==12.1.1
 + python-dotenv==1.2.2
 + python-telegram-bot==22.6
 + telegramify-markdown==0.5.4
 + typing-extensions==4.15.0
Installed 1 executable: ccbot
2026-03-11 18:21:24,731 - ccbot.main - INFO - Allowed users: {USERID}
2026-03-11 18:21:24,731 - ccbot.main - INFO - Claude projects path: /Users/USER/.claude/projects
2026-03-11 18:21:24,749 - ccbot.main - INFO - Tmux session 'ccbot' ready
2026-03-11 18:21:24,749 - ccbot.main - INFO - Starting Telegram bot...
2026-03-11 18:21:28,533 - ccbot.bot - INFO - Pre-filled global rate limiter bucket
2026-03-11 18:21:28,533 - ccbot.monitor_state - INFO - Loaded 1 tracked sessions from state
2026-03-11 18:21:28,533 - ccbot.bot - INFO - Session monitor started
2026-03-11 18:21:28,533 - ccbot.handlers.status_polling - INFO - Status polling started (interval: 1.0s)
2026-03-11 18:21:28,533 - ccbot.session_monitor - INFO - Session monitor started, polling every 2.0s
2026-03-11 18:21:28,566 - ccbot.monitor_state - DEBUG - Saved 1 tracked sessions to state
```