### PR TITLE
feat: add CCBOT_SHOW_TOOL_CALLS and CCBOT_SHOW_USER_MESSAGES env vars

### DIFF
--- a/src/ccbot/bot.py
+++ b/src/ccbot/bot.py
@@ -1767,6 +1767,10 @@ async def handle_new_message(msg: NewMessage, bot: Bot) -> None:
         if get_interactive_msg_id(user_id, thread_id):
             await clear_interactive_msg(user_id, bot, thread_id)
 
+        # Skip tool call notifications when CCBOT_SHOW_TOOL_CALLS=false
+        if not config.show_tool_calls and msg.content_type in ("tool_use", "tool_result"):
+            continue
+
         parts = build_response_parts(
             msg.text,
             msg.is_complete,

--- a/src/ccbot/config.py
+++ b/src/ccbot/config.py
@@ -86,7 +86,15 @@ class Config:
 
         # Display user messages in history and real-time notifications
         # When True, user messages are shown with a 👤 prefix
-        self.show_user_messages = True
+        self.show_user_messages = (
+            os.getenv("CCBOT_SHOW_USER_MESSAGES", "true").lower() != "false"
+        )
+
+        # Show tool call notifications (tool_use/tool_result) in Telegram
+        # When False, only text responses, thinking, and interactive prompts are sent
+        self.show_tool_calls = (
+            os.getenv("CCBOT_SHOW_TOOL_CALLS", "true").lower() != "false"
+        )
 
         # Show hidden (dot) directories in directory browser
         self.show_hidden_dirs = (


### PR DESCRIPTION
## Summary
- Adds `CCBOT_SHOW_TOOL_CALLS` env var (default: `true`) — when set to `false`, suppresses `tool_use` and `tool_result` messages from being sent to Telegram
- Wires up `CCBOT_SHOW_USER_MESSAGES` env var (default: `true`) to the existing `show_user_messages` config flag, which was previously hardcoded to `True`
- Both default to `true` for full backward compatibility

## Motivation
When using the Telegram bridge to passively monitor Claude Code sessions, tool call notifications (Read, Edit, Bash, Glob, Grep, etc.) and echoed user messages create significant noise that crowds out the meaningful text responses. These env vars let users opt into a cleaner feed.

## Test plan
- [ ] Set `CCBOT_SHOW_TOOL_CALLS=false` in `.env`, restart ccbot, verify tool_use/tool_result messages are no longer sent to Telegram
- [ ] Set `CCBOT_SHOW_USER_MESSAGES=false` in `.env`, restart ccbot, verify user messages are no longer echoed
- [ ] Verify both default to `true` when env vars are unset (backward compat)
- [ ] Verify interactive tool prompts (AskUserQuestion, permissions) still appear when tool calls are hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)