### PR TITLE
fix: auto-rebind topic when tmux window is recreated with same name

### DIFF
--- a/src/ccbot/bot.py
+++ b/src/ccbot/bot.py
@@ -933,19 +933,49 @@ async def text_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     w = await tmux_manager.find_window_by_id(wid)
     if not w:
         display = session_manager.get_display_name(wid)
-        logger.info(
-            "Stale binding: window %s gone, unbinding (user=%d, thread=%d)",
-            display,
-            user.id,
-            thread_id,
-        )
-        session_manager.unbind_thread(user.id, thread_id)
-        await safe_reply(
-            update.message,
-            f"❌ Window '{display}' no longer exists. Binding removed.\n"
-            "Send a message to start a new session.",
-        )
-        return
+        # Try auto-rebind: find unbound window with same name
+        all_windows = await tmux_manager.list_windows()
+        bound_wids = {
+            bw
+            for _, _, bw in session_manager.iter_thread_bindings()
+            if bw != wid
+        }
+        candidates = [
+            win
+            for win in all_windows
+            if win.window_name == display and win.window_id not in bound_wids
+        ]
+        if len(candidates) == 1:
+            replacement = candidates[0]
+            logger.info(
+                "Auto-rebinding stale window %s -> %s "
+                "(name=%s, user=%d, thread=%d)",
+                wid,
+                replacement.window_id,
+                display,
+                user.id,
+                thread_id,
+            )
+            session_manager.unbind_thread(user.id, thread_id)
+            session_manager.bind_thread(
+                user.id, thread_id, replacement.window_id, window_name=display
+            )
+            wid = replacement.window_id
+            w = replacement
+        else:
+            logger.info(
+                "Stale binding: window %s gone, unbinding (user=%d, thread=%d)",
+                display,
+                user.id,
+                thread_id,
+            )
+            session_manager.unbind_thread(user.id, thread_id)
+            await safe_reply(
+                update.message,
+                f"❌ Window '{display}' no longer exists. Binding removed.\n"
+                "Send a message to start a new session.",
+            )
+            return
 
     await update.message.chat.send_action(ChatAction.TYPING)
     await enqueue_status_update(context.bot, user.id, wid, None, thread_id=thread_id)

--- a/src/ccbot/handlers/status_polling.py
+++ b/src/ccbot/handlers/status_polling.py
@@ -170,6 +170,40 @@ async def status_poll_loop(bot: Bot) -> None:
                     # Clean up stale bindings (window no longer exists)
                     w = await tmux_manager.find_window_by_id(wid)
                     if not w:
+                        display = session_manager.get_display_name(wid)
+                        # Try auto-rebind: find unbound window with same name
+                        all_windows = await tmux_manager.list_windows()
+                        bound_wids = {
+                            bw
+                            for _, _, bw in session_manager.iter_thread_bindings()
+                            if bw != wid
+                        }
+                        candidates = [
+                            win
+                            for win in all_windows
+                            if win.window_name == display
+                            and win.window_id not in bound_wids
+                        ]
+                        if len(candidates) == 1:
+                            replacement = candidates[0]
+                            logger.info(
+                                "Auto-rebinding stale window %s -> %s "
+                                "(name=%s, user=%d, thread=%d)",
+                                wid,
+                                replacement.window_id,
+                                display,
+                                user_id,
+                                thread_id,
+                            )
+                            session_manager.unbind_thread(user_id, thread_id)
+                            session_manager.bind_thread(
+                                user_id,
+                                thread_id,
+                                replacement.window_id,
+                                window_name=display,
+                            )
+                            continue
+
                         session_manager.unbind_thread(user_id, thread_id)
                         await clear_topic_state(user_id, thread_id, bot)
                         logger.info(


### PR DESCRIPTION
## Summary
- When a tmux window is closed and recreated with the same name at runtime, automatically rebind the topic to the new window instead of requiring manual re-binding
- Applies to both background `status_polling` (within 1s) and the message handler (on next user message)
- Only auto-rebinds when exactly one unbound window matches by name (no ambiguity)

Closes #61

## Test plan
- [ ] Bind a topic to a tmux window (e.g., "Main")
- [ ] Close the tmux window externally
- [ ] Create a new tmux window with the same name
- [ ] Verify the topic auto-rebinds (check logs for "Auto-rebinding stale window")
- [ ] Send a message in the topic and verify it reaches the new window
- [ ] Test with multiple same-name windows — should NOT auto-rebind (falls back to unbind + window picker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)