### PR TITLE
feat: configurable thinking truncation via CCBOT_MAX_THINKING_CHARS

### DIFF
--- a/src/ccbot/bot.py
+++ b/src/ccbot/bot.py
@@ -1776,6 +1776,7 @@ async def handle_new_message(msg: NewMessage, bot: Bot) -> None:
             msg.is_complete,
             msg.content_type,
             msg.role,
+            max_thinking_chars=config.max_thinking_chars,
         )
 
         if msg.is_complete:

--- a/src/ccbot/config.py
+++ b/src/ccbot/config.py
@@ -96,6 +96,10 @@ class Config:
             os.getenv("CCBOT_SHOW_TOOL_CALLS", "true").lower() != "false"
         )
 
+        # Max characters for thinking content before truncation.
+        # 0 = no truncation (full thinking forwarded to Telegram).
+        self.max_thinking_chars = int(os.getenv("CCBOT_MAX_THINKING_CHARS", "0"))
+
         # Show hidden (dot) directories in directory browser
         self.show_hidden_dirs = (
             os.getenv("CCBOT_SHOW_HIDDEN_DIRS", "").lower() == "true"

--- a/src/ccbot/handlers/response_builder.py
+++ b/src/ccbot/handlers/response_builder.py
@@ -23,12 +23,16 @@ def build_response_parts(
     is_complete: bool,
     content_type: str = "text",
     role: str = "assistant",
+    max_thinking_chars: int = 0,
 ) -> list[str]:
     """Build paginated response messages for Telegram.
 
     Returns a list of raw markdown strings, each within Telegram's 4096 char limit.
     Multi-part messages get a [1/N] suffix.
     Markdown-to-MarkdownV2 conversion is done by the send layer, not here.
+
+    Args:
+        max_thinking_chars: Max characters for thinking content. 0 = no truncation.
     """
     text = text.strip()
 
@@ -41,18 +45,17 @@ def build_response_parts(
             text = text[:3000] + "…"
         return [f"{prefix}{text}"]
 
-    # Truncate thinking content to keep it compact
-    if content_type == "thinking" and is_complete:
+    # Truncate thinking content to keep it compact (0 = disabled)
+    if max_thinking_chars > 0 and content_type == "thinking" and is_complete:
         start_tag = TranscriptParser.EXPANDABLE_QUOTE_START
         end_tag = TranscriptParser.EXPANDABLE_QUOTE_END
-        max_thinking = 500
         if start_tag in text and end_tag in text:
             inner = text[text.index(start_tag) + len(start_tag) : text.index(end_tag)]
-            if len(inner) > max_thinking:
-                inner = inner[:max_thinking] + "\n\n… (thinking truncated)"
+            if len(inner) > max_thinking_chars:
+                inner = inner[:max_thinking_chars] + "\n\n… (thinking truncated)"
             text = start_tag + inner + end_tag
-        elif len(text) > max_thinking:
-            text = text[:max_thinking] + "\n\n… (thinking truncated)"
+        elif len(text) > max_thinking_chars:
+            text = text[:max_thinking_chars] + "\n\n… (thinking truncated)"
 
     # Format based on content type
     if content_type == "thinking":

--- a/tests/ccbot/handlers/test_response_builder.py
+++ b/tests/ccbot/handlers/test_response_builder.py
@@ -21,10 +21,29 @@ class TestBuildResponseParts:
         assert len(parts[0]) < len(long_text)
         assert len(short_parts[0]) < len(parts[0])
 
-    def test_thinking_content_truncated_at_500_chars(self):
+    def test_thinking_not_truncated_by_default(self):
         inner = "x" * 800
         text = f"{EXP_START}{inner}{EXP_END}"
         parts = build_response_parts(text, is_complete=True, content_type="thinking")
+        assert len(parts) == 1
+        assert "truncated" not in parts[0].lower()
+        assert inner in parts[0]
+
+    def test_thinking_truncated_when_max_set(self):
+        inner = "x" * 800
+        text = f"{EXP_START}{inner}{EXP_END}"
+        parts = build_response_parts(
+            text, is_complete=True, content_type="thinking", max_thinking_chars=500
+        )
+        assert len(parts) == 1
+        assert "truncated" in parts[0].lower()
+        assert inner not in parts[0]
+
+    def test_thinking_truncated_plain_text(self):
+        text = "y" * 800
+        parts = build_response_parts(
+            text, is_complete=True, content_type="thinking", max_thinking_chars=500
+        )
         assert len(parts) == 1
         assert "truncated" in parts[0].lower()
 


### PR DESCRIPTION
## Summary

- **Configurable thinking truncation**: Replace hardcoded 500-char limit with `CCBOT_MAX_THINKING_CHARS` env var. Defaults to `0` (no truncation, full thinking forwarded to Telegram). Set to e.g. `500` to restore compact thinking messages.

## Changes

### `src/ccbot/handlers/response_builder.py`
- `build_response_parts()` gains `max_thinking_chars` parameter (default `0`)
- When `max_thinking_chars > 0`, truncates thinking content at the configured limit
- When `0` (default), full thinking content is forwarded unchanged

### `src/ccbot/config.py`
- New config field: `max_thinking_chars` from `CCBOT_MAX_THINKING_CHARS` env var (default `0`)

### `src/ccbot/bot.py`
- Passes `config.max_thinking_chars` to `build_response_parts()`

### `tests/ccbot/handlers/test_response_builder.py`
- Tests for default (no truncation), truncation with expandable quotes, and plain text truncation

## Usage

```bash
# Default: no truncation (full thinking)
ccbot

# Restore old behavior: truncate at 500 chars
CCBOT_MAX_THINKING_CHARS=500 ccbot
```

## Test plan
- [x] All 10 tests pass
- [x] `ruff check` passes
- [x] `ruff format` passes (our files)
- [x] `pyright` — 0 errors

Note: pre-existing `ruff format` failure on `bot.py` is unrelated to this PR (see comment).