### PR TITLE
Fix interactive UI creating duplicate messages on button press

### DIFF
--- a/src/ccbot/handlers/interactive_ui.py
+++ b/src/ccbot/handlers/interactive_ui.py
@@ -17,6 +17,7 @@ State dicts are keyed by (user_id, thread_id_or_0) for Telegram topic support.
 import logging
 
 from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.error import BadRequest
 
 from ..session import session_manager
 from ..terminal_parser import extract_interactive_content, is_interactive_ui
@@ -202,13 +203,24 @@ async def handle_interactive_ui(
             )
             _interactive_mode[ikey] = window_id
             return True
-        except Exception:
-            # Edit failed (message deleted, etc.) - clear stale msg_id and send new
+        except BadRequest as e:
+            if "Message is not modified" in str(e):
+                # Content unchanged — keep existing message as-is
+                _interactive_mode[ikey] = window_id
+                return True
+            # Other edit failure — fall through to send new message,
+            # but keep old message until replacement succeeds
             logger.debug(
-                "Edit failed for interactive msg %s, sending new", existing_msg_id
+                "Edit failed for interactive msg %s: %s, sending new",
+                existing_msg_id,
+                e,
             )
-            _interactive_msgs.pop(ikey, None)
-            # Fall through to send new message
+        except Exception as e:
+            logger.debug(
+                "Edit failed for interactive msg %s: %s, sending new",
+                existing_msg_id,
+                e,
+            )
 
     # Send new message (plain text — terminal content is not markdown)
     logger.info(
@@ -228,6 +240,12 @@ async def handle_interactive_ui(
     if sent:
         _interactive_msgs[ikey] = sent.message_id
         _interactive_mode[ikey] = window_id
+        # New message sent successfully — now safe to delete the old one
+        if existing_msg_id:
+            try:
+                await bot.delete_message(chat_id=chat_id, message_id=existing_msg_id)
+            except Exception:
+                pass  # Old message may already be gone
         return True
     return False
 


### PR DESCRIPTION
## Summary
- Handle `BadRequest: Message is not modified` specifically — keep existing message instead of creating a duplicate
- Delete old message before sending new one when edit genuinely fails, ensuring at most one interactive UI message per topic

## Problem
Each button press (Up/Down/Enter/Space/Tab) on interactive UI inline keyboards could create a **new** message instead of editing the existing one. This happened because `handle_interactive_ui` caught all exceptions from `edit_message_text` and fell through to `send_message` without deleting the old message.

The most common trigger: Telegram raises `BadRequest: Message is not modified` when terminal content hasn't changed after a button press — the broad `except Exception` treated this as a failure and sent a duplicate.

## Changes
Only `src/ccbot/handlers/interactive_ui.py`:
1. Import `BadRequest` from `telegram.error`
2. Catch `BadRequest` with "Message is not modified" → return `True` (keep existing message)
3. On other edit failures → `delete_message` the old one before sending new

## Test plan
- [ ] Press interactive UI buttons (Up/Down/Space/Enter) rapidly — should always have exactly one UI message
- [ ] Delete the UI message externally in Telegram, then press a button — should send a fresh message (no error)
- [ ] Verify AskUserQuestion, PermissionPrompt, ExitPlanMode all work correctly

Fixes #66