### PR TITLE
fix: stop renaming user-created Telegram topics on bind

### DIFF
--- a/src/ccbot/bot.py
+++ b/src/ccbot/bot.py
@@ -1063,17 +1063,6 @@ async def _create_and_bind_window(
                 user.id, pending_thread_id, created_wid, window_name=created_wname
             )
 
-            # Rename the topic to match the window name
-            resolved_chat = session_manager.resolve_chat_id(user.id, pending_thread_id)
-            try:
-                await context.bot.edit_forum_topic(
-                    chat_id=resolved_chat,
-                    message_thread_id=pending_thread_id,
-                    name=created_wname,
-                )
-            except Exception as e:
-                logger.debug(f"Failed to rename topic: {e}")
-
             status = "Resumed" if resume_session_id else "Created"
             await safe_edit(
                 query,
@@ -1460,17 +1449,6 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         session_manager.bind_thread(
             user.id, thread_id, selected_wid, window_name=display
         )
-
-        # Rename the topic to match the window name
-        resolved_chat = session_manager.resolve_chat_id(user.id, thread_id)
-        try:
-            await context.bot.edit_forum_topic(
-                chat_id=resolved_chat,
-                message_thread_id=thread_id,
-                name=display,
-            )
-        except Exception as e:
-            logger.debug(f"Failed to rename topic: {e}")
 
         await safe_edit(
             query,


### PR DESCRIPTION
## Summary

- Removes the automatic topic rename when binding a thread to a window
- Users who create their own named topics in the Telegram supergroup lose their chosen name when ccbot renames it to match the tmux window name
- This preserves user-created topic names while still binding correctly

## Test plan

- [ ] Create a custom-named topic in the supergroup
- [ ] Use `/start` to bind it to a session
- [ ] Verify the topic keeps its original name

🤖 Generated with [Claude Code](https://claude.ai/code)