### PR TITLE
Fix hook writing wrong session prefix under grouped tmux sessions

### DIFF
--- a/src/ccbot/hook.py
+++ b/src/ccbot/hook.py
@@ -215,7 +215,16 @@ def hook_main() -> None:
             raw_output,
         )
         return
-    tmux_session_name, window_id, window_name = parts
+    _raw_session_name, window_id, window_name = parts
+    # Force canonical tmux session name from config (TMUX_SESSION_NAME env).
+    # When hook runs in a pane attached via a grouped session (e.g.
+    # `tmux new -t ccbot -s view-A`), tmux reports the grouped name
+    # ("view-A") instead of the canonical one ("ccbot"). That breaks
+    # session_monitor's `startswith("ccbot:")` filter, and recv-direction
+    # forwarding (JSONL -> Telegram) silently stops working.
+    # Grouped sessions share the same window set, so window_id is the same
+    # across all views; always writing the canonical prefix is unambiguous.
+    tmux_session_name = os.environ.get("TMUX_SESSION_NAME", "ccbot")
     # Key uses window_id for uniqueness
     session_window_key = f"{tmux_session_name}:{window_id}"
 


### PR DESCRIPTION
When a user attaches to the ccbot tmux session via a grouped session (e.g. `tmux new -t ccbot -s view-A` for independent client focus) and then starts claude inside a window, the SessionStart hook captures the grouped session name ("view-A") from `tmux display-message` instead of the canonical name from config ("ccbot").

The resulting session_map key looks like `view-A:@3` instead of `ccbot:@3`. Session_monitor's `_load_current_session_map` filters keys with `startswith("ccbot:")` and silently drops all view-prefixed entries. Result: recv-direction forwarding (JSONL -> Telegram) never works for any session started this way, while send-direction (tmux send-keys) still works — which is especially confusing to debug.

Since grouped sessions share the same window set in tmux, window_id is unambiguous across all views. Always writing the canonical prefix (from TMUX_SESSION_NAME env / config.tmux_session_name) correctly identifies the window regardless of which view triggered the hook.