### PR TITLE
fix(main): broaden allowed_updates so Telegram delivers forum service messages

### DIFF
--- a/src/ccbot/main.py
+++ b/src/ccbot/main.py
@@ -58,7 +58,27 @@ def main() -> None:
     from .bot import create_bot
 
     application = create_bot()
-    application.run_polling(allowed_updates=["message", "callback_query"])
+    # Subscribe to a broader set of update types than the original
+    # ["message", "callback_query"]. Empirically, Telegram stopped delivering
+    # forum_topic_edited service messages (which arrive as `message` updates
+    # per the docs) when only "message" and "callback_query" were subscribed —
+    # observed silently dropped renames between May 15 and May 20, 2026, even
+    # though Telegram's own docs list forum_topic_edited as a Message field.
+    # Adding the broader set below restored delivery. Suspect cause: a
+    # server-side change where Telegram now treats minimal allowed_updates as
+    # a signal to suppress peripheral service messages.
+    application.run_polling(
+        allowed_updates=[
+            "message",
+            "edited_message",
+            "channel_post",
+            "edited_channel_post",
+            "callback_query",
+            "my_chat_member",
+            "chat_member",
+            "chat_join_request",
+        ]
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Empirically, Telegram stopped delivering `forum_topic_edited` service messages to bots subscribed only to `allowed_updates=[\"message\", \"callback_query\"]`. This broke the topic-rename → tmux window rename sync (`topic_edited_handler`) for ccbot deployments around mid-May 2026.

`forum_topic_edited` is documented as a field on `Message`, delivered via the `message` update type. So in principle, subscribing to `message` should suffice. In practice, it doesn't — these service messages are silently dropped at Telegram's side unless additional update types are also subscribed. Suspected cause: a server-side change where minimal `allowed_updates` is now treated as a signal to suppress peripheral service messages.

## Diagnosis

In my deployment:

- Up to ~2026-05-15: `topic_edited_handler` fired reliably; renames synced to tmux window names.
- After ~2026-05-15: zero `Topic renamed` log entries despite multiple confirmed user-side renames (Telegram's own \"Topic name changed to …\" service message visible in the chat).
- Verified the events weren't reaching the handler via a `TypeHandler` at `group=-1` that logged every update — zero `forum_topic_edited` updates arrived.
- `forum_topic_closed` (also a service message in a `message` update) **continued working** through 2026-05-19 — so the bot's update pipeline is functional in general; only forum-topic *edits* are affected.
- Other ruled-out hypotheses: bot privacy mode (`can_read_all_group_messages: true`), admin status (`can_manage_topics: true`), user permissions (chat creator, not anonymous), python-telegram-bot version, handler registration ordering.
- Expanding `allowed_updates` to a broader list immediately restored delivery; renames flowed within seconds of the bot restart.

I did not bisect which single additional update type is the magic key. The 6-type expansion in this PR is safe (the bot ignores them via existing filters or doesn't subscribe handlers for them) and matches the pragmatic minimum that covers the regression.

## Change

Expand `allowed_updates` in `main.py:run_polling` from 2 types to 8:

\`\`\`
\"message\", \"edited_message\", \"channel_post\", \"edited_channel_post\",
\"callback_query\", \"my_chat_member\", \"chat_member\", \"chat_join_request\"
\`\`\`

All additions are inert for current handler set — no behavior change beyond restoring `forum_topic_edited` delivery.

## Test plan

- [x] Reproduce silent rename-drop on `["message", "callback_query"]` (verified May 19–20)
- [x] Apply patch; rename topic; observe `Topic renamed:` log + `tmux rename-window` syncing the window name (verified May 20)
- [x] Verify `topic_closed_handler` still works (the close path was never affected)
- [x] Confirm no new behavior from added update types (no new handlers, existing filters unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)