### PR TITLE
fix: don't drop Telegram messages when send_action times out before tmux injection

### DIFF
--- a/src/ccbot/bot.py
+++ b/src/ccbot/bot.py
@@ -520,7 +520,10 @@ async def forward_command_handler(
     logger.info(
         "Forwarding command %s to window %s (user=%d)", cc_slash, display, user.id
     )
-    await update.message.chat.send_action(ChatAction.TYPING)
+    try:
+        await update.message.chat.send_action(ChatAction.TYPING)
+    except Exception as e:
+        logger.warning("send_action(TYPING) failed, continuing to injection: %s", e)
     success, message = await session_manager.send_to_window(wid, cc_slash)
     if success:
         await safe_reply(update.message, f"⚡ [{display}] Sent: {cc_slash}")
@@ -619,7 +622,10 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     else:
         text_to_send = f"(image attached: {file_path})"
 
-    await update.message.chat.send_action(ChatAction.TYPING)
+    try:
+        await update.message.chat.send_action(ChatAction.TYPING)
+    except Exception as e:
+        logger.warning("send_action(TYPING) failed, continuing to injection: %s", e)
     clear_status_msg_info(user.id, thread_id)
 
     success, message = await session_manager.send_to_window(wid, text_to_send)
@@ -696,7 +702,10 @@ async def voice_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         await safe_reply(update.message, f"⚠ Transcription failed: {e}")
         return
 
-    await update.message.chat.send_action(ChatAction.TYPING)
+    try:
+        await update.message.chat.send_action(ChatAction.TYPING)
+    except Exception as e:
+        logger.warning("send_action(TYPING) failed, continuing to injection: %s", e)
     clear_status_msg_info(user.id, thread_id)
 
     success, message = await session_manager.send_to_window(wid, text)
@@ -947,25 +956,43 @@ async def text_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         )
         return
 
-    await update.message.chat.send_action(ChatAction.TYPING)
-    await enqueue_status_update(context.bot, user.id, wid, None, thread_id=thread_id)
+    # Cosmetic / outbound-Telegram steps below must NEVER abort the handler
+    # before the message is injected into tmux. On flaky networks the "typing…"
+    # indicator (send_action) and status enqueue time out (telegram.error.TimedOut);
+    # since the update offset has already advanced, Telegram won't redeliver, so
+    # any exception here silently drops the user's message and forces a resend.
+    try:
+        await update.message.chat.send_action(ChatAction.TYPING)
+    except Exception as e:
+        logger.warning("send_action(TYPING) failed, continuing to injection: %s", e)
+    try:
+        await enqueue_status_update(
+            context.bot, user.id, wid, None, thread_id=thread_id
+        )
+    except Exception as e:
+        logger.warning("enqueue_status_update failed, continuing to injection: %s", e)
 
     # Cancel any running bash capture — new message pushes pane content down
     _cancel_bash_capture(user.id, thread_id)
 
     # Check for pending interactive UI before sending text.
     # This catches UIs (permission prompts, etc.) that status polling might have missed.
-    pane_text = await tmux_manager.capture_pane(w.window_id)
-    if pane_text and is_interactive_ui(pane_text):
-        # UI detected — show it to user, then send text (acts as Enter)
-        logger.info(
-            "Detected pending interactive UI before sending text (user=%d, thread=%s)",
-            user.id,
-            thread_id,
-        )
-        await handle_interactive_ui(context.bot, user.id, wid, thread_id)
-        # Small delay to let UI render in Telegram before text arrives
-        await asyncio.sleep(0.3)
+    # capture_pane is a local tmux call, but handle_interactive_ui hits the network —
+    # isolate the whole block so a failure can't prevent the injection below.
+    try:
+        pane_text = await tmux_manager.capture_pane(w.window_id)
+        if pane_text and is_interactive_ui(pane_text):
+            # UI detected — show it to user, then send text (acts as Enter)
+            logger.info(
+                "Detected pending interactive UI before sending text (user=%d, thread=%s)",
+                user.id,
+                thread_id,
+            )
+            await handle_interactive_ui(context.bot, user.id, wid, thread_id)
+            # Small delay to let UI render in Telegram before text arrives
+            await asyncio.sleep(0.3)
+    except Exception as e:
+        logger.warning("interactive-UI precheck failed, continuing to injection: %s", e)
 
     success, message = await session_manager.send_to_window(wid, text)
     if not success:


### PR DESCRIPTION
## Symptom

On a flaky network (e.g. reaching `api.telegram.org` from mainland China), messages sent from Telegram intermittently never reach the tmux session. The user has to resend 2–3 times before one gets through, with no error shown.

## Root cause

In `text_handler` (and `photo_handler` / `voice_handler` / `forward_command_handler`), a **cosmetic outbound-Telegram call** — `chat.send_action(ChatAction.TYPING)`, the "typing…" indicator — runs **before** the message is injected into tmux via `send_to_window`, with no error isolation. The bot also registers no global error handler (`No error handlers are registered` in logs).

Sequence in `text_handler` (pre-fix):

| line | call | nature |
|------|------|--------|
| 950 | `send_action(TYPING)` | **outbound Telegram network** ← raises here |
| 951 | `enqueue_status_update(...)` | outbound Telegram network |
| 958 | `capture_pane` + interactive-UI precheck | local tmux (safe) |
| 970 | `send_to_window(wid, text)` | **the actual injection** |

When `send_action` raises `telegram.error.TimedOut`, the exception propagates out of the handler (no error handler), so execution never reaches line 970 — the message is never injected. Because the update offset has already advanced, Telegram does **not** redeliver, so the message is lost and the user must resend.

## Evidence (from a ~7-day production log)

- `telegram.error.TimedOut` raised at `bot.py:950 in text_handler`, aborting before injection: **129 occurrences**.
- Every one ends in `telegram.error.TimedOut: Timed out` inside `send_chat_action`.
- For contrast, inbound `get_updates` timeouts (82) are harmless — they self-recover because the offset isn't advanced, so Telegram redelivers.

```
File ".../ccbot/bot.py", line 950, in text_handler
    await update.message.chat.send_action(ChatAction.TYPING)
File ".../telegram/_chat.py", line 1270, in send_chat_action
    ...
telegram.error.TimedOut: Timed out
```

## Fix

Wrap every pre-injection outbound-Telegram call (`send_action`, `enqueue_status_update`) and the interactive-UI precheck in `try/except` so a transient network failure can never prevent the tmux injection. `send_to_window` is the one call that must always run. Applied to all four handlers that send `TYPING` before injecting. Ordering/semantics are unchanged (the UI precheck still runs first when it can); only the cosmetic calls' ability to abort the critical path is removed.

A complementary hardening (not in this PR) would be registering a global `application.add_error_handler(...)` so any future handler exception is at least logged and optionally surfaced to the user.

---

Note: while diagnosing this, `ccbot --version` / `--help` were observed to boot a second daemon (no early-exit), which then fights the running instance for `getUpdates` and raises `telegram.error.Conflict: terminated by other getUpdates request`. Might be worth a real `--version`/`--help` that exits without starting the bot.