### PR TITLE
feat: configurable transcription model for OpenAI-compatible backends

### DIFF
--- a/src/ccbot/config.py
+++ b/src/ccbot/config.py
@@ -106,6 +106,12 @@ class Config:
         self.openai_base_url: str = os.getenv(
             "OPENAI_BASE_URL", "https://api.openai.com/v1"
         )
+        # Transcription model — override when pointing OPENAI_BASE_URL at an
+        # OpenAI-compatible backend that serves different model names (e.g. a
+        # local Whisper server such as Speaches). Default: OpenAI's hosted model.
+        self.transcribe_model: str = os.getenv(
+            "CCBOT_TRANSCRIBE_MODEL", "gpt-4o-transcribe"
+        )
 
         # Scrub sensitive vars from os.environ so child processes never inherit them.
         # Values are already captured in Config attributes above.

--- a/src/ccbot/transcribe.py
+++ b/src/ccbot/transcribe.py
@@ -1,7 +1,9 @@
 """Voice-to-text transcription via OpenAI's audio API.
 
-Provides a single async function to transcribe voice messages using
-the gpt-4o-transcribe model. Uses httpx directly (no OpenAI SDK needed).
+Provides a single async function to transcribe voice messages using a
+configurable model (default: gpt-4o-transcribe). Works with any
+OpenAI-compatible /audio/transcriptions endpoint. Uses httpx directly
+(no OpenAI SDK needed).
 
 Key function: transcribe_voice(ogg_data) -> str
 """
@@ -38,7 +40,7 @@ async def transcribe_voice(ogg_data: bytes) -> str:
         url,
         headers={"Authorization": f"Bearer {config.openai_api_key}"},
         files={"file": ("voice.ogg", ogg_data, "audio/ogg")},
-        data={"model": "gpt-4o-transcribe"},
+        data={"model": config.transcribe_model},
     )
     response.raise_for_status()
 


### PR DESCRIPTION
Closes #90.

## What

Add `CCBOT_TRANSCRIBE_MODEL` (default `gpt-4o-transcribe`) so the voice-transcription model is configurable, mirroring `OPENAI_BASE_URL` / `OPENAI_API_KEY`. This lets ccbot use any OpenAI-compatible `/audio/transcriptions` backend, not just OpenAI's hosted API.

## Why

See #90. `OPENAI_BASE_URL` already made the endpoint configurable, but the hardcoded model name blocked OpenAI-compatible backends that serve different model names. Use case: a local [Speaches](https://github.com/speaches-ai/speaches) instance running Whisper `large-v3-turbo` (faster-whisper) on the LAN, for private/offline transcription.

## Changes

- `src/ccbot/config.py`: `self.transcribe_model = os.getenv("CCBOT_TRANSCRIBE_MODEL", "gpt-4o-transcribe")`
- `src/ccbot/transcribe.py`: use `config.transcribe_model` instead of the hardcoded literal; module docstring generalized.

Minimal and backwards compatible (2 files, ~11 lines). No behaviour change when the var is unset.

## Verification

- `ruff check` + `pyright`: clean.
- End-to-end against a local Speaches (Whisper `large-v3-turbo`): a Telegram voice message was transcribed correctly and forwarded to the Claude session.

## Notes

- Naming: used the `CCBOT_` prefix for consistency with `CCBOT_SHOW_*`. Happy to rename if you prefer e.g. `OPENAI_TRANSCRIBE_MODEL`.
- The existing guard in `voice_handler` requires a non-empty `OPENAI_API_KEY` even for no-auth backends; workaround is any dummy value. Decoupling auth from enablement is left as a possible follow-up, out of scope here.