### PR TITLE
fix: keep parsing the status line when a tip block follows it

### DIFF
--- a/src/ccbot/terminal_parser.py
+++ b/src/ccbot/terminal_parser.py
@@ -226,15 +226,19 @@ def parse_status_line(pane_text: str) -> str | None:
     if chrome_idx is None:
         return None  # No chrome visible — can't determine status
 
-    # Check lines just above the separator (skip blanks, up to 4 lines)
-    for i in range(chrome_idx - 1, max(chrome_idx - 5, -1), -1):
+    # Scan upward for the spinner line. Claude Code can render a tip block
+    # between the status line and the chrome, so keep looking past non-spinner
+    # lines — but once we're past the line directly above the separator, only a
+    # live status line counts. The ellipsis is what marks one, and it keeps
+    # prose bullets and the finished marker ("✻ Sautéed for 7s") out.
+    adjacent = True
+    for i in range(chrome_idx - 1, max(chrome_idx - 9, -1), -1):
         line = lines[i].strip()
         if not line:
             continue
-        if line[0] in STATUS_SPINNERS:
+        if line[0] in STATUS_SPINNERS and (adjacent or "…" in line):
             return line[1:].strip()
-        # First non-empty line above separator isn't a spinner → no status
-        return None
+        adjacent = False
     return None
 
 

--- a/tests/ccbot/test_terminal_parser.py
+++ b/tests/ccbot/test_terminal_parser.py
@@ -59,6 +59,23 @@ class TestParseStatusLine:
         pane = f"· bullet point one\n· bullet point two\nsome result\n{chrome}"
         assert parse_status_line(pane) is None
 
+    def test_tip_block_between_status_and_chrome(self, chrome: str):
+        """Claude Code renders a tip block under the status line."""
+        pane = (
+            "some output\n"
+            "✳ Gitifying… (2m 1s · ↓ 6.5k tokens)\n"
+            "  ⎿ Tip: Use /btw to ask a quick side question without interrupting\n"
+            "     current work\n"
+            "\n"
+            f"{chrome}"
+        )
+        assert parse_status_line(pane) == "Gitifying… (2m 1s · ↓ 6.5k tokens)"
+
+    def test_finished_marker_is_not_status(self, chrome: str):
+        """The completed marker carries no ellipsis and must not count."""
+        pane = f"some output\n✻ Sautéed for 7s\nsome result\n{chrome}"
+        assert parse_status_line(pane) is None
+
     def test_uses_fixture(self, sample_pane_status_line: str):
         assert parse_status_line(sample_pane_status_line) == "Reading file src/main.py"
 


### PR DESCRIPTION
## Problem

`parse_status_line` locates the chrome separator, then checks the first non-blank line above it. If that line doesn't start with a spinner glyph it returns `None` immediately.

Claude Code now renders a tip block between the status line and the chrome:

```
✳ Gitifying… (2m 1s · ↓ 6.5k tokens)
  ⎿ Tip: Use /btw to ask a quick side question without interrupting
     current work
────────────────────────────────────────
❯
────────────────────────────────────────
  ⏸ manual mode on · esc to interrupt · ← for agents
```

The scan stops on `current work` and reports no status. Whenever a tip is showing, the topic's status message goes stale — it keeps displaying whatever was last parsed until the tip disappears.

## Fix

Keep scanning upward instead of bailing on the first non-spinner line.

The line directly above the separator is still accepted on the spinner glyph alone, so current behaviour is unchanged. Past that, a line must also carry the `…` of a live status line. That preserves the guard the original was written for — `·` bullets in Claude's prose output — and additionally keeps out the finished marker (`✻ Sautéed for 7s`), which has no ellipsis.

Every status line variant carries the ellipsis, including the ones quoted in #52:

```
✻ Thinking… 5s
✶ Coalescing… (25m 8s · ↓ 5.8k tokens · thought for 6s)
✢ Drizzling… (54s · ↓ 776 tokens)
```

## Tests

Two added, and all existing `parse_status_line` tests pass unchanged:

- the tip-block layout parses correctly
- the finished `✻ Sautéed for 7s` marker is not mistaken for a live status
