### PR TITLE
fix: register bot commands on all scopes so groups get a "/" menu

### DIFF
--- a/src/ccbot/bot.py
+++ b/src/ccbot/bot.py
@@ -41,6 +41,9 @@ from pathlib import Path
 from telegram import (
     Bot,
     BotCommand,
+    BotCommandScopeAllChatAdministrators,
+    BotCommandScopeAllGroupChats,
+    BotCommandScopeAllPrivateChats,
     InlineKeyboardButton,
     InlineKeyboardMarkup,
     InputMediaDocument,
@@ -1836,7 +1839,19 @@ async def handle_new_message(msg: NewMessage, bot: Bot) -> None:
 async def post_init(application: Application) -> None:
     global session_monitor, _status_poll_task
 
-    await application.bot.delete_my_commands()
+    # Clear every scope we might have written before, plus stale scopes left by
+    # earlier setups (BotFather, older versions).  A narrower scope beats the
+    # default scope, so a stale all_private_chats list hides the real menu.
+    for scope in (
+        None,
+        BotCommandScopeAllPrivateChats(),
+        BotCommandScopeAllGroupChats(),
+        BotCommandScopeAllChatAdministrators(),
+    ):
+        try:
+            await application.bot.delete_my_commands(scope=scope)
+        except Exception as e:
+            logger.warning("delete_my_commands(%s) failed: %s", scope, e)
 
     bot_commands = [
         BotCommand("start", "Show welcome message"),
@@ -1851,7 +1866,18 @@ async def post_init(application: Application) -> None:
     for cmd_name, desc in CC_COMMANDS.items():
         bot_commands.append(BotCommand(cmd_name, desc))
 
-    await application.bot.set_my_commands(bot_commands)
+    # Register on every scope the bot is used from.  Clients read the scope that
+    # matches the chat, so forum topics need all_group_chats set explicitly —
+    # falling back to default is unreliable for the composer's "/" button.
+    for scope in (
+        None,
+        BotCommandScopeAllPrivateChats(),
+        BotCommandScopeAllGroupChats(),
+    ):
+        try:
+            await application.bot.set_my_commands(bot_commands, scope=scope)
+        except Exception as e:
+            logger.warning("set_my_commands(%s) failed: %s", scope, e)
 
     # Re-resolve stale window IDs from persisted state against live tmux windows
     await session_manager.resolve_stale_ids()

--- a/src/ccbot/bot.py
+++ b/src/ccbot/bot.py
@@ -148,12 +148,17 @@ _status_poll_task: asyncio.Task | None = None
 
 # Claude Code commands shown in bot menu (forwarded via tmux)
 CC_COMMANDS: dict[str, str] = {
+    "agents": "↗ Manage subagents",
     "clear": "↗ Clear conversation history",
     "compact": "↗ Compact conversation context",
+    "context": "↗ Show context window usage",
     "cost": "↗ Show token/cost usage",
     "help": "↗ Show Claude Code help",
     "memory": "↗ Edit CLAUDE.md",
     "model": "↗ Switch AI model",
+    "recap": "↗ Summarize this session",
+    "status": "↗ Show session status",
+    "tasks": "↗ List background tasks and subagents",
 }
 
 


### PR DESCRIPTION
## Problem

`set_my_commands` is only ever called for the default scope, and
`delete_my_commands` only clears that one.

Telegram resolves a chat's command list from the most specific scope that
matches, so:

- a stale `all_private_chats` list — left by BotFather or an earlier version —
  keeps overriding the default list in private chats, and nothing in ccbot
  clears it;
- `all_group_chats` is never written at all, so a bot used from a group shows
  no "/" menu. Forum topics are where this bites hardest, since that menu is
  the only discoverable way to reach the forwarded Claude Code commands.

## Change

`post_init` now clears each scope that may hold a stale list, then registers
the full command list on the default, private and group scopes. Both calls
tolerate a rejected scope so one failure cannot stop startup.

Also adds five Claude Code commands to `CC_COMMANDS` — `/agents`, `/context`,
`/status`, `/tasks` and `/recap` — each verified present in Claude Code
2.1.233. Menu names are limited to lowercase letters, digits and underscores,
so hyphenated commands can't be listed as-is.

## Verification

`pytest` (258 passed), `pyright src/ccbot/` clean, `ruff format --check` clean.

This registration has been running against a forum-topic supergroup for the
past few days, where the "/" menu previously did not appear at all.

## Related

- #68 registers user skills as bot commands — complementary rather than
  competing, though it touches the same registration code, and its
  hyphen-to-underscore conversion would cover the naming limit noted above.
- This deliberately leaves `/kill` alone. It is advertised in the menu with no
  handler behind it, but #81 and #46 both already address that.
